### PR TITLE
chore: ignore eslint 10.x in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,13 @@ updates:
       timezone: Etc/UTC
     labels:
       - automated
+    # eslint-plugin-github@6 (latest) locks @typescript-eslint to v8, which only
+    # supports eslint ^8||^9. Until eslint-plugin-github ships a version that
+    # uses @typescript-eslint v9+, eslint 10.x will break linting.
+    ignore:
+      - dependency-name: eslint
+        versions:
+          - 10.x
     cooldown:
       semver-patch-days: 3
       semver-minor-days: 7


### PR DESCRIPTION
eslint-plugin-github@6 (latest) locks @typescript-eslint to v8, which only
supports eslint ^8||^9. Until eslint-plugin-github ships a version using
@typescript-eslint v9+, any eslint 10.x bump will break linting.

https://claude.ai/code/session_013W7hDFSviFFuDbqEdAC348