### PR TITLE
Fix admonition formatting for skipped/missing commits

### DIFF
--- a/dist/index.mjs
+++ b/dist/index.mjs
@@ -66536,32 +66536,11 @@ async function compareCommits(owner, repo, base, head) {
 var LEGACY_COMMENT_TAG_PATTERN = `<!-- thollander/actions-comment-pull-request "comment-flake-lock-changelog" -->`;
 var COMMENT_TAG_PATTERN = `<!-- mdarocha/comment-flake-lock-changelog -->`;
 var GITHUB_COMMENT_MAX_LENGTH = 65536;
-var TRUNCATION_NOTICE = `
-
-> [!NOTE]
-> The changelog was truncated because it exceeded GitHub's maximum comment size of 65,536 characters.`;
-function buildCommentBody(body2) {
-  const tag = `
-${COMMENT_TAG_PATTERN}`;
-  const full = `${body2}${tag}`;
-  if (full.length <= GITHUB_COMMENT_MAX_LENGTH) {
-    return full;
-  }
-  const available = GITHUB_COMMENT_MAX_LENGTH - tag.length - TRUNCATION_NOTICE.length;
-  const cutIndex = body2.lastIndexOf(`
-`, available);
-  const safeBody = cutIndex > 0 ? body2.slice(0, cutIndex) : body2.slice(0, available);
-  return `${safeBody}${TRUNCATION_NOTICE}${tag}`;
-}
 async function upsertComment(prNumber, body2) {
   const client = getGithubClient();
   const { repo } = context4;
-  const wouldExceed = `${body2}
-${COMMENT_TAG_PATTERN}`.length > GITHUB_COMMENT_MAX_LENGTH;
-  if (wouldExceed) {
-    warning("Comment body exceeded GitHub's maximum comment size of 65,536 characters and was truncated.");
-  }
-  const taggedBody = buildCommentBody(body2);
+  const taggedBody = `${body2}
+${COMMENT_TAG_PATTERN}`;
   function hasCommentTag(comment) {
     return comment?.body?.includes(COMMENT_TAG_PATTERN) === true || comment?.body?.includes(LEGACY_COMMENT_TAG_PATTERN) === true;
   }
@@ -66731,6 +66710,7 @@ async function run() {
       result.push(`[\`${diff.beforeRev}\` -> \`${diff.rev}\`](https://github.com/${diff.owner}/${diff.repo}/compare/${diff.beforeRev}..${diff.rev})`);
       const commits = await compareCommits(diff.owner, diff.repo, diff.beforeRev, diff.rev);
       if (commits.length === 0) {
+        result.push("");
         result.push("> [!NOTE]");
         result.push("> Could not generate a detailed changelog — the commits have no common ancestor. " + "The repository history may have been rewritten.");
       }
@@ -66758,15 +66738,16 @@ async function run() {
         result.push(line);
         bodySize += line.length + 1;
       }
-      if (omitted > 0) {
-        result.push("");
-        result.push("> [!NOTE]");
-        result.push(`> ${omitted} more commit(s) were omitted. ` + `[View the full comparison on GitHub](https://github.com/${diff.owner}/${diff.repo}/compare/${diff.beforeRev}..${diff.rev}).`);
-      }
       result.push("");
       result.push("</details>");
       result.push("");
       await saveCacheForRepo(diff.owner, diff.repo);
+      if (omitted > 0) {
+        result.push("");
+        result.push("> [!NOTE]");
+        result.push(`> ${omitted} more commit(s) were not shown (comment size limit). [View full comparison](https://github.com/${diff.owner}/${diff.repo}/compare/${diff.beforeRev}..${diff.rev})`);
+        result.push("");
+      }
     }
   }
   info("Posting comment to PR");

--- a/dist/index.mjs
+++ b/dist/index.mjs
@@ -66695,12 +66695,48 @@ async function run() {
   }
   const TAG_OVERHEAD = `
 ${COMMENT_TAG_PATTERN}`.length;
+  function diffHeaderBlock(diff) {
+    return [
+      `### [${diff.owner}/${diff.repo}](https://github.com/${diff.owner}/${diff.repo})`,
+      "",
+      "<details><summary>Changelog</summary>",
+      "",
+      `[\`${diff.beforeRev}\` -> \`${diff.rev}\`](https://github.com/${diff.owner}/${diff.repo}/compare/${diff.beforeRev}..${diff.rev})`
+    ].join(`
+`);
+  }
+  function noCommonAncestorBlock() {
+    return [
+      "",
+      "> [!NOTE]",
+      "> Could not generate a detailed changelog — the commits have no common ancestor. " + "The repository history may have been rewritten."
+    ].join(`
+`);
+  }
+  function closingBlock() {
+    return ["", "</details>", ""].join(`
+`);
+  }
   function buildOmittedNote(owner, repo, beforeRev, rev, count) {
     return `
 
 > [!NOTE]
 ` + `> ${count} more commit(s) were not shown (comment size limit). ` + `[View full comparison](https://github.com/${owner}/${repo}/compare/${beforeRev}..${rev})
 `;
+  }
+  function commitListItem(commit) {
+    const commitMessage = commit.message.replace(/@/g, "@‍");
+    const commitUrl = commit.url.replace("https://github.com", "https://redirect.github.com");
+    return `- [${commitMessage}](${commitUrl})`;
+  }
+  async function buildCommitLine(diff, commit) {
+    const item = commitListItem(commit);
+    const pr = await getPullRequestForCommit(diff.owner, diff.repo, commit.sha);
+    if (!pr) {
+      return item;
+    }
+    const prUrl = pr.url.replace("https://github.com", "https://redirect.github.com");
+    return `${item} - [![PR Icon](https://icongr.am/octicons/git-pull-request.svg?size=14&color=abb4bf) PR #${pr.id}](${prUrl})`;
   }
   const result = ["# Flake inputs changelog"];
   info(`Fetching changed files for PR #${prNumber}`);
@@ -66727,54 +66763,64 @@ ${COMMENT_TAG_PATTERN}`.length;
       return;
     }
   }
+  const gathered = [];
   for (const { lockfile, diffs } of allDiffsByLockfile) {
-    result.push(`## ${lockfile}`);
     for (const diff of diffs) {
       info(`Checking ${diff.owner}/${diff.repo} ${diff.beforeRev} -> ${diff.rev}`);
       await restoreCacheForRepo(diff.owner, diff.repo);
-      result.push(`### [${diff.owner}/${diff.repo}](https://github.com/${diff.owner}/${diff.repo})`);
-      result.push("");
-      result.push("<details><summary>Changelog</summary>");
-      result.push("");
-      result.push(`[\`${diff.beforeRev}\` -> \`${diff.rev}\`](https://github.com/${diff.owner}/${diff.repo}/compare/${diff.beforeRev}..${diff.rev})`);
       const commits = await compareCommits(diff.owner, diff.repo, diff.beforeRev, diff.rev);
-      if (commits.length === 0) {
-        result.push("");
-        result.push("> [!NOTE]");
-        result.push("> Could not generate a detailed changelog — the commits have no common ancestor. " + "The repository history may have been rewritten.");
-      }
-      let bodySize = result.join(`
-`).length;
-      let omitted = 0;
-      const reserve = TAG_OVERHEAD + buildOmittedNote(diff.owner, diff.repo, diff.beforeRev, diff.rev, commits.length).length + 1;
-      for (let i = 0;i < commits.length; i++) {
-        const commit = commits[i];
-        const commitMessage = commit.message.replace(/@/g, "@‍");
-        const commitUrl = commit.url.replace("https://github.com", "https://redirect.github.com");
-        const commitListItem = `- [${commitMessage}](${commitUrl})`;
-        info(`Checking for PRs associated with commit ${commit.sha}`);
-        const pr = await getPullRequestForCommit(diff.owner, diff.repo, commit.sha);
-        let line;
-        if (pr) {
-          const prUrl = pr.url.replace("https://github.com", "https://redirect.github.com");
-          line = `${commitListItem} - [![PR Icon](https://icongr.am/octicons/git-pull-request.svg?size=14&color=abb4bf) PR #${pr.id}](${prUrl})`;
-        } else {
-          line = commitListItem;
-        }
-        if (bodySize + line.length + 1 + reserve > GITHUB_COMMENT_MAX_LENGTH) {
-          omitted = commits.length - i;
-          break;
-        }
-        result.push(line);
-        bodySize += line.length + 1;
-      }
-      result.push("");
-      result.push("</details>");
-      result.push("");
+      const firstLine = commits.length > 0 ? await buildCommitLine(diff, commits[0]) : null;
+      gathered.push({ lockfile, diff, commits, firstLine });
+    }
+  }
+  let reserved = TAG_OVERHEAD;
+  const seenLockfiles = new Set;
+  for (const { lockfile, diff, commits, firstLine } of gathered) {
+    if (!seenLockfiles.has(lockfile)) {
+      seenLockfiles.add(lockfile);
+      reserved += `## ${lockfile}`.length + 1;
+    }
+    reserved += diffHeaderBlock(diff).length + 1;
+    reserved += closingBlock().length + 1;
+    if (commits.length === 0) {
+      reserved += noCommonAncestorBlock().length + 1;
+    } else {
+      reserved += firstLine.length + 1;
+      reserved += buildOmittedNote(diff.owner, diff.repo, diff.beforeRev, diff.rev, commits.length).length + 1;
+    }
+  }
+  let discretionaryBudget = Math.max(0, GITHUB_COMMENT_MAX_LENGTH - result.join(`
+`).length - reserved);
+  let lastLockfile = null;
+  for (const { lockfile, diff, commits, firstLine } of gathered) {
+    if (lockfile !== lastLockfile) {
+      result.push(`## ${lockfile}`);
+      lastLockfile = lockfile;
+    }
+    result.push(diffHeaderBlock(diff));
+    if (commits.length === 0) {
+      result.push(noCommonAncestorBlock());
+      result.push(closingBlock());
       await saveCacheForRepo(diff.owner, diff.repo);
-      if (omitted > 0) {
-        result.push(buildOmittedNote(diff.owner, diff.repo, diff.beforeRev, diff.rev, omitted));
+      continue;
+    }
+    result.push(firstLine);
+    let omitted = 0;
+    for (let i = 1;i < commits.length; i++) {
+      const commit = commits[i];
+      info(`Checking for PRs associated with commit ${commit.sha}`);
+      const line = await buildCommitLine(diff, commit);
+      if (line.length + 1 > discretionaryBudget) {
+        omitted = commits.length - i;
+        break;
       }
+      result.push(line);
+      discretionaryBudget -= line.length + 1;
+    }
+    result.push(closingBlock());
+    await saveCacheForRepo(diff.owner, diff.repo);
+    if (omitted > 0) {
+      result.push(buildOmittedNote(diff.owner, diff.repo, diff.beforeRev, diff.rev, omitted));
     }
   }
   info("Posting comment to PR");

--- a/dist/index.mjs
+++ b/dist/index.mjs
@@ -66536,11 +66536,32 @@ async function compareCommits(owner, repo, base, head) {
 var LEGACY_COMMENT_TAG_PATTERN = `<!-- thollander/actions-comment-pull-request "comment-flake-lock-changelog" -->`;
 var COMMENT_TAG_PATTERN = `<!-- mdarocha/comment-flake-lock-changelog -->`;
 var GITHUB_COMMENT_MAX_LENGTH = 65536;
+var TRUNCATION_NOTICE = `
+
+> [!NOTE]
+> The changelog was truncated because it exceeded GitHub's maximum comment size of 65,536 characters.`;
+function buildCommentBody(body2) {
+  const tag = `
+${COMMENT_TAG_PATTERN}`;
+  const full = `${body2}${tag}`;
+  if (full.length <= GITHUB_COMMENT_MAX_LENGTH) {
+    return full;
+  }
+  const available = GITHUB_COMMENT_MAX_LENGTH - tag.length - TRUNCATION_NOTICE.length;
+  const cutIndex = body2.lastIndexOf(`
+`, available);
+  const safeBody = cutIndex > 0 ? body2.slice(0, cutIndex) : body2.slice(0, available);
+  return `${safeBody}${TRUNCATION_NOTICE}${tag}`;
+}
 async function upsertComment(prNumber, body2) {
   const client = getGithubClient();
   const { repo } = context4;
-  const taggedBody = `${body2}
-${COMMENT_TAG_PATTERN}`;
+  const wouldExceed = `${body2}
+${COMMENT_TAG_PATTERN}`.length > GITHUB_COMMENT_MAX_LENGTH;
+  if (wouldExceed) {
+    warning("Comment body exceeded GitHub's maximum comment size of 65,536 characters and was truncated.");
+  }
+  const taggedBody = buildCommentBody(body2);
   function hasCommentTag(comment) {
     return comment?.body?.includes(COMMENT_TAG_PATTERN) === true || comment?.body?.includes(LEGACY_COMMENT_TAG_PATTERN) === true;
   }
@@ -66611,7 +66632,7 @@ async function restoreCacheForRepo(owner, repo) {
     const raw = fs7.readFileSync(filePath, "utf8");
     const cacheFile = JSON.parse(raw);
     for (const [k, v] of Object.entries(cacheFile.compareCommits)) {
-      compareCommitsCache.set(k, v.commits);
+      compareCommitsCache.set(k, v);
     }
     for (const [k, v] of Object.entries(cacheFile.prForCommit)) {
       prForCommitCache.set(k, v);
@@ -66625,7 +66646,7 @@ async function saveCacheForRepo(owner, repo) {
   try {
     const compareCommitsEntries = {};
     for (const [k, commits] of compareCommitsCache.entries()) {
-      compareCommitsEntries[k] = { commits, skippedCount: 0 };
+      compareCommitsEntries[k] = commits;
     }
     const prForCommitEntries = {};
     for (const [k, v] of prForCommitCache.entries()) {
@@ -66672,7 +66693,15 @@ async function run() {
   if (isNaN(prNumber) || prNumber === 0) {
     throw new Error(`Invalid pull request number: ${prNumber}`);
   }
-  const COMMIT_TRUNCATION_OVERHEAD = 350;
+  const TAG_OVERHEAD = `
+${COMMENT_TAG_PATTERN}`.length;
+  function buildOmittedNote(owner, repo, beforeRev, rev, count) {
+    return `
+
+> [!NOTE]
+` + `> ${count} more commit(s) were not shown (comment size limit). ` + `[View full comparison](https://github.com/${owner}/${repo}/compare/${beforeRev}..${rev})
+`;
+  }
   const result = ["# Flake inputs changelog"];
   info(`Fetching changed files for PR #${prNumber}`);
   const files = await getPullRequestChangedFiles(prNumber);
@@ -66717,6 +66746,7 @@ async function run() {
       let bodySize = result.join(`
 `).length;
       let omitted = 0;
+      const reserve = TAG_OVERHEAD + buildOmittedNote(diff.owner, diff.repo, diff.beforeRev, diff.rev, commits.length).length + 1;
       for (let i = 0;i < commits.length; i++) {
         const commit = commits[i];
         const commitMessage = commit.message.replace(/@/g, "@‍");
@@ -66731,7 +66761,7 @@ async function run() {
         } else {
           line = commitListItem;
         }
-        if (bodySize + line.length + 1 + COMMIT_TRUNCATION_OVERHEAD > GITHUB_COMMENT_MAX_LENGTH) {
+        if (bodySize + line.length + 1 + reserve > GITHUB_COMMENT_MAX_LENGTH) {
           omitted = commits.length - i;
           break;
         }
@@ -66743,10 +66773,7 @@ async function run() {
       result.push("");
       await saveCacheForRepo(diff.owner, diff.repo);
       if (omitted > 0) {
-        result.push("");
-        result.push("> [!NOTE]");
-        result.push(`> ${omitted} more commit(s) were not shown (comment size limit). [View full comparison](https://github.com/${diff.owner}/${diff.repo}/compare/${diff.beforeRev}..${diff.rev})`);
-        result.push("");
+        result.push(buildOmittedNote(diff.owner, diff.repo, diff.beforeRev, diff.rev, omitted));
       }
     }
   }

--- a/dist/index.mjs
+++ b/dist/index.mjs
@@ -66799,8 +66799,8 @@ ${COMMENT_TAG_PATTERN}`.length;
     }
     result.push(diffHeaderBlock(diff));
     if (commits.length === 0) {
-      result.push(noCommonAncestorBlock());
       result.push(closingBlock());
+      result.push(noCommonAncestorBlock());
       await saveCacheForRepo(diff.owner, diff.repo);
       continue;
     }

--- a/src/api.test.ts
+++ b/src/api.test.ts
@@ -291,33 +291,6 @@ describe("upsertComment", () => {
         expect(body).toBe(`new body\n${COMMENT_TAG}`);
         expect(createCommentMock).not.toHaveBeenCalled();
     });
-
-    test("truncates body and emits warning when over 65,536 characters", async () => {
-        const body = "x".repeat(70_000);
-
-        await upsertComment(1, body);
-
-        const { body: posted } = (createCommentMock.mock.calls[0] as [{ body: string }])[0];
-        expect(posted.length).toBeLessThanOrEqual(65536);
-        expect(posted.endsWith(`\n${COMMENT_TAG}`)).toBe(true);
-        expect(posted).toContain("[!NOTE]");
-        expect(posted).toContain("truncated");
-        expect(logMock).toHaveBeenCalledWith(
-            "Comment body exceeded GitHub's maximum comment size of 65,536 characters and was truncated.",
-        );
-    });
-
-    test("does not truncate or warn when body fits within the limit", async () => {
-        const tag = `\n${COMMENT_TAG}`;
-        const body = "x".repeat(65536 - tag.length);
-
-        await upsertComment(1, body);
-
-        const { body: posted } = (createCommentMock.mock.calls[0] as [{ body: string }])[0];
-        expect(posted.length).toBe(65536);
-        expect(posted).not.toContain("[!NOTE]");
-        expect(logMock).not.toHaveBeenCalled();
-    });
 });
 
 describe("getPullRequestDetails", () => {

--- a/src/api.test.ts
+++ b/src/api.test.ts
@@ -291,6 +291,33 @@ describe("upsertComment", () => {
         expect(body).toBe(`new body\n${COMMENT_TAG}`);
         expect(createCommentMock).not.toHaveBeenCalled();
     });
+
+    test("truncates body and emits warning when over 65,536 characters", async () => {
+        const body = "x".repeat(70_000);
+
+        await upsertComment(1, body);
+
+        const { body: posted } = (createCommentMock.mock.calls[0] as [{ body: string }])[0];
+        expect(posted.length).toBeLessThanOrEqual(65536);
+        expect(posted.endsWith(`\n${COMMENT_TAG}`)).toBe(true);
+        expect(posted).toContain("[!NOTE]");
+        expect(posted).toContain("truncated");
+        expect(logMock).toHaveBeenCalledWith(
+            "Comment body exceeded GitHub's maximum comment size of 65,536 characters and was truncated.",
+        );
+    });
+
+    test("does not truncate or warn when body fits within the limit", async () => {
+        const tag = `\n${COMMENT_TAG}`;
+        const body = "x".repeat(65536 - tag.length);
+
+        await upsertComment(1, body);
+
+        const { body: posted } = (createCommentMock.mock.calls[0] as [{ body: string }])[0];
+        expect(posted.length).toBe(65536);
+        expect(posted).not.toContain("[!NOTE]");
+        expect(logMock).not.toHaveBeenCalled();
+    });
 });
 
 describe("getPullRequestDetails", () => {

--- a/src/api.ts
+++ b/src/api.ts
@@ -118,38 +118,12 @@ const COMMENT_TAG_PATTERN = `<!-- mdarocha/comment-flake-lock-changelog -->`;
 
 // GitHub enforces a hard 65,536-character limit on issue/PR comment bodies.
 export const GITHUB_COMMENT_MAX_LENGTH = 65536;
-const TRUNCATION_NOTICE =
-    "\n\n> [!NOTE]\n> The changelog was truncated because it exceeded GitHub's maximum comment size of 65,536 characters.";
-
-/**
- * Attaches the identity tag to `body` and truncates the result to GitHub's
- * comment-size limit.  When truncation is needed the body is cut at the last
- * complete line that fits, and `TRUNCATION_NOTICE` is appended so readers know
- * the output is incomplete.
- */
-function buildCommentBody(body: string): string {
-    const tag = `\n${COMMENT_TAG_PATTERN}`;
-    const full = `${body}${tag}`;
-    if (full.length <= GITHUB_COMMENT_MAX_LENGTH) {
-        return full;
-    }
-    // Reserve space for the tag and the truncation notice, then cut at the
-    // last newline within the available window to avoid breaking markdown.
-    const available = GITHUB_COMMENT_MAX_LENGTH - tag.length - TRUNCATION_NOTICE.length;
-    const cutIndex = body.lastIndexOf("\n", available);
-    const safeBody = cutIndex > 0 ? body.slice(0, cutIndex) : body.slice(0, available);
-    return `${safeBody}${TRUNCATION_NOTICE}${tag}`;
-}
 
 export async function upsertComment(prNumber: number, body: string): Promise<void> {
     const client = getGithubClient();
     const { repo } = github.context;
 
-    const wouldExceed = `${body}\n${COMMENT_TAG_PATTERN}`.length > GITHUB_COMMENT_MAX_LENGTH;
-    if (wouldExceed) {
-        core.warning("Comment body exceeded GitHub's maximum comment size of 65,536 characters and was truncated.");
-    }
-    const taggedBody = buildCommentBody(body);
+    const taggedBody = `${body}\n${COMMENT_TAG_PATTERN}`;
 
     function hasCommentTag(comment: { body?: string | null }): boolean {
         return (

--- a/src/api.ts
+++ b/src/api.ts
@@ -114,16 +114,42 @@ export async function compareCommits(
 }
 
 const LEGACY_COMMENT_TAG_PATTERN = `<!-- thollander/actions-comment-pull-request "comment-flake-lock-changelog" -->`;
-const COMMENT_TAG_PATTERN = `<!-- mdarocha/comment-flake-lock-changelog -->`;
+export const COMMENT_TAG_PATTERN = `<!-- mdarocha/comment-flake-lock-changelog -->`;
 
 // GitHub enforces a hard 65,536-character limit on issue/PR comment bodies.
 export const GITHUB_COMMENT_MAX_LENGTH = 65536;
+const TRUNCATION_NOTICE =
+    "\n\n> [!NOTE]\n> The changelog was truncated because it exceeded GitHub's maximum comment size of 65,536 characters.";
+
+/**
+ * Attaches the identity tag to `body` and truncates the result to GitHub's
+ * comment-size limit.  When truncation is needed the body is cut at the last
+ * complete line that fits, and `TRUNCATION_NOTICE` is appended so readers know
+ * the output is incomplete.
+ */
+function buildCommentBody(body: string): string {
+    const tag = `\n${COMMENT_TAG_PATTERN}`;
+    const full = `${body}${tag}`;
+    if (full.length <= GITHUB_COMMENT_MAX_LENGTH) {
+        return full;
+    }
+    // Reserve space for the tag and the truncation notice, then cut at the
+    // last newline within the available window to avoid breaking markdown.
+    const available = GITHUB_COMMENT_MAX_LENGTH - tag.length - TRUNCATION_NOTICE.length;
+    const cutIndex = body.lastIndexOf("\n", available);
+    const safeBody = cutIndex > 0 ? body.slice(0, cutIndex) : body.slice(0, available);
+    return `${safeBody}${TRUNCATION_NOTICE}${tag}`;
+}
 
 export async function upsertComment(prNumber: number, body: string): Promise<void> {
     const client = getGithubClient();
     const { repo } = github.context;
 
-    const taggedBody = `${body}\n${COMMENT_TAG_PATTERN}`;
+    const wouldExceed = `${body}\n${COMMENT_TAG_PATTERN}`.length > GITHUB_COMMENT_MAX_LENGTH;
+    if (wouldExceed) {
+        core.warning("Comment body exceeded GitHub's maximum comment size of 65,536 characters and was truncated.");
+    }
+    const taggedBody = buildCommentBody(body);
 
     function hasCommentTag(comment: { body?: string | null }): boolean {
         return (
@@ -203,10 +229,7 @@ export async function getPullRequestDetails(prNumber: number): Promise<PullReque
 }
 
 interface CacheFile {
-    compareCommits: Record<
-        string,
-        { commits: Array<{ sha: string; message: string; url: string }>; skippedCount: number }
-    >;
+    compareCommits: Record<string, Array<{ sha: string; message: string; url: string }>>;
     prForCommit: Record<string, { id: number; url: string } | null>;
 }
 
@@ -226,7 +249,7 @@ export async function restoreCacheForRepo(owner: string, repo: string): Promise<
         const raw = fs.readFileSync(filePath, "utf8");
         const cacheFile = JSON.parse(raw) as CacheFile;
         for (const [k, v] of Object.entries(cacheFile.compareCommits)) {
-            compareCommitsCache.set(k, v.commits);
+            compareCommitsCache.set(k, v);
         }
         for (const [k, v] of Object.entries(cacheFile.prForCommit)) {
             prForCommitCache.set(k, v);
@@ -241,7 +264,7 @@ export async function saveCacheForRepo(owner: string, repo: string): Promise<voi
     try {
         const compareCommitsEntries: CacheFile["compareCommits"] = {};
         for (const [k, commits] of compareCommitsCache.entries()) {
-            compareCommitsEntries[k] = { commits, skippedCount: 0 };
+            compareCommitsEntries[k] = commits;
         }
         const prForCommitEntries: CacheFile["prForCommit"] = {};
         for (const [k, v] of prForCommitCache.entries()) {

--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -20,6 +20,7 @@ const COMPARE_URL = "https://github.com/NixOS/nixpkgs/compare/aaaa1111..bbbb2222
 let moduleMocks: Array<Awaited<ReturnType<typeof mockModule>>> = [];
 let upsertCommentMock: Mock<(prNumber: number, body: string) => Promise<void>>;
 let getPullRequestDetailsMock: Mock<() => Promise<PullRequestDetails>>;
+let getFileContentAtCommitMock: Mock<(commit: string, path: string) => Promise<string>>;
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 let compareCommitsMock: Mock<any>;
 
@@ -29,6 +30,9 @@ beforeEach(async () => {
         authorLogin: "dependabot[bot]",
         body: COMPARE_URL,
     }));
+    getFileContentAtCommitMock = mock(async (commit: string, _path: string) =>
+        commit === "basesha" ? BEFORE_LOCK : AFTER_LOCK,
+    );
     compareCommitsMock = mock(async () => []);
 
     moduleMocks = [
@@ -40,9 +44,7 @@ beforeEach(async () => {
         await mockModule("~/api", () => ({
             getPullRequestChangedFiles: mock(async () => ["flake.lock"]),
             getPullRequestRefs: mock(async () => ({ base: "basesha", head: "headsha" })),
-            getFileContentAtCommit: mock(async (commit: string, _path: string) =>
-                commit === "basesha" ? BEFORE_LOCK : AFTER_LOCK,
-            ),
+            getFileContentAtCommit: getFileContentAtCommitMock,
             getPullRequestDetails: getPullRequestDetailsMock,
             compareCommits: compareCommitsMock,
             getPullRequestForCommit: mock(async () => null),
@@ -119,6 +121,54 @@ describe("run", () => {
         expect(closingIndex).toBeGreaterThan(-1);
         expect(noteIndex).toBeGreaterThan(closingIndex);
         // Room must be left for the identity tag appended by upsertComment.
+        expect(body.length).toBeLessThan(65536);
+    });
+
+    test("guarantees every input's header and first commit even when other inputs also need truncation", async () => {
+        getPullRequestDetailsMock.mockImplementation(async () => ({
+            authorLogin: "someone",
+            body: "",
+        }));
+
+        const BEFORE_TWO_INPUTS = JSON.stringify({
+            nodes: {
+                root: { inputs: { nixpkgs: "nixpkgs", utils: "utils" } },
+                nixpkgs: { locked: { owner: "NixOS", repo: "nixpkgs", rev: "aaaa1111", type: "github" } },
+                utils: { locked: { owner: "numtide", repo: "flake-utils", rev: "cccc3333", type: "github" } },
+            },
+        });
+        const AFTER_TWO_INPUTS = JSON.stringify({
+            nodes: {
+                root: { inputs: { nixpkgs: "nixpkgs", utils: "utils" } },
+                nixpkgs: { locked: { owner: "NixOS", repo: "nixpkgs", rev: "bbbb2222", type: "github" } },
+                utils: { locked: { owner: "numtide", repo: "flake-utils", rev: "dddd4444", type: "github" } },
+            },
+        });
+        getFileContentAtCommitMock.mockImplementation(async (commit: string, _path: string) =>
+            commit === "basesha" ? BEFORE_TWO_INPUTS : AFTER_TWO_INPUTS,
+        );
+
+        // Both inputs individually would overflow the comment size limit on their own,
+        // so satisfying both requires the reserve to be computed across all inputs up
+        // front rather than input-by-input.
+        compareCommitsMock.mockImplementation(async (owner: string, repo: string) =>
+            Array.from({ length: 2000 }, (_, i) => ({
+                sha: `${repo}-sha${i}`,
+                message: `commit ${i} in ${repo}, padded so this line is long enough to overflow the size budget`,
+                url: `https://github.com/${owner}/${repo}/commit/${repo}-sha${i}`,
+            })),
+        );
+
+        // dynamic import required: same reason as above.
+        const { run } = await import("~/main");
+        await run();
+
+        const [, body] = upsertCommentMock.mock.calls[0];
+        expect(body).toContain("### [NixOS/nixpkgs]");
+        expect(body).toContain("### [numtide/flake-utils]");
+        expect(body).toContain("commit 0 in nixpkgs");
+        expect(body).toContain("commit 0 in flake-utils");
+        expect((body.match(/more commit\(s\) were not shown/g) ?? []).length).toBeGreaterThanOrEqual(1);
         expect(body.length).toBeLessThan(65536);
     });
 });

--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -18,8 +18,10 @@ const AFTER_LOCK = JSON.stringify({
 const COMPARE_URL = "https://github.com/NixOS/nixpkgs/compare/aaaa1111..bbbb2222";
 
 let moduleMocks: Array<Awaited<ReturnType<typeof mockModule>>> = [];
-let upsertCommentMock: Mock<() => Promise<void>>;
+let upsertCommentMock: Mock<(prNumber: number, body: string) => Promise<void>>;
 let getPullRequestDetailsMock: Mock<() => Promise<PullRequestDetails>>;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let compareCommitsMock: Mock<any>;
 
 beforeEach(async () => {
     upsertCommentMock = mock(async () => {});
@@ -27,6 +29,7 @@ beforeEach(async () => {
         authorLogin: "dependabot[bot]",
         body: COMPARE_URL,
     }));
+    compareCommitsMock = mock(async () => []);
 
     moduleMocks = [
         await mockModule("@actions/core", () => ({
@@ -41,7 +44,7 @@ beforeEach(async () => {
                 commit === "basesha" ? BEFORE_LOCK : AFTER_LOCK,
             ),
             getPullRequestDetails: getPullRequestDetailsMock,
-            compareCommits: mock(async () => ({ commits: [], skippedCount: 0 })),
+            compareCommits: compareCommitsMock,
             getPullRequestForCommit: mock(async () => null),
             upsertComment: upsertCommentMock,
             restoreCacheForRepo: mock(async () => {}),
@@ -74,5 +77,48 @@ describe("run", () => {
         const { run } = await import("~/main");
         await run();
         expect(upsertCommentMock).toHaveBeenCalledTimes(1);
+    });
+
+    test("places the no-common-ancestor note outside the accordion", async () => {
+        getPullRequestDetailsMock.mockImplementation(async () => ({
+            authorLogin: "someone",
+            body: "",
+        }));
+        // dynamic import required: same reason as above.
+        const { run } = await import("~/main");
+        await run();
+
+        const [, body] = upsertCommentMock.mock.calls[0];
+        const noteIndex = body.indexOf("[!WARNING]") !== -1 ? body.indexOf("[!WARNING]") : body.indexOf("[!NOTE]");
+        const closingIndex = body.indexOf("</details>");
+        expect(noteIndex).toBeGreaterThan(-1);
+        expect(closingIndex).toBeGreaterThan(-1);
+        expect(noteIndex).toBeLessThan(closingIndex);
+    });
+
+    test("places the omitted-commits note outside the accordion and reserves room for the identity tag", async () => {
+        getPullRequestDetailsMock.mockImplementation(async () => ({
+            authorLogin: "someone",
+            body: "",
+        }));
+        compareCommitsMock.mockImplementation(async () =>
+            Array.from({ length: 2000 }, (_, i) => ({
+                sha: `sha${i}`,
+                message: `commit number ${i} padded so the list overflows the comment size limit`,
+                url: `https://github.com/NixOS/nixpkgs/commit/sha${i}`,
+            })),
+        );
+        // dynamic import required: same reason as above.
+        const { run } = await import("~/main");
+        await run();
+
+        const [, body] = upsertCommentMock.mock.calls[0];
+        const closingIndex = body.indexOf("</details>");
+        const noteIndex = body.indexOf("more commit(s) were not shown");
+        expect(noteIndex).toBeGreaterThan(-1);
+        expect(closingIndex).toBeGreaterThan(-1);
+        expect(noteIndex).toBeGreaterThan(closingIndex);
+        // Room must be left for the identity tag appended by upsertComment.
+        expect(body.length).toBeLessThan(65536);
     });
 });

--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -41,7 +41,7 @@ beforeEach(async () => {
                 commit === "basesha" ? BEFORE_LOCK : AFTER_LOCK,
             ),
             getPullRequestDetails: getPullRequestDetailsMock,
-            compareCommits: mock(async () => []),
+            compareCommits: mock(async () => ({ commits: [], skippedCount: 0 })),
             getPullRequestForCommit: mock(async () => null),
             upsertComment: upsertCommentMock,
             restoreCacheForRepo: mock(async () => {}),

--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import type { Mock } from "bun:test";
+import { COMMENT_TAG_PATTERN, GITHUB_COMMENT_MAX_LENGTH } from "~/api";
 import type { PullRequestDetails } from "~/api";
 import { mockModule } from "~/utils/mockModule";
 
@@ -95,7 +96,7 @@ describe("run", () => {
         const closingIndex = body.indexOf("</details>");
         expect(noteIndex).toBeGreaterThan(-1);
         expect(closingIndex).toBeGreaterThan(-1);
-        expect(noteIndex).toBeLessThan(closingIndex);
+        expect(noteIndex).toBeGreaterThan(closingIndex);
     });
 
     test("places the omitted-commits note outside the accordion and reserves room for the identity tag", async () => {
@@ -120,8 +121,10 @@ describe("run", () => {
         expect(noteIndex).toBeGreaterThan(-1);
         expect(closingIndex).toBeGreaterThan(-1);
         expect(noteIndex).toBeGreaterThan(closingIndex);
-        // Room must be left for the identity tag appended by upsertComment.
-        expect(body.length).toBeLessThan(65536);
+        // upsertComment is mocked here, so it never actually appends the identity tag —
+        // add its real length back in to confirm the *tagged* body would still fit.
+        const taggedLength = body.length + `\n${COMMENT_TAG_PATTERN}`.length;
+        expect(taggedLength).toBeLessThanOrEqual(GITHUB_COMMENT_MAX_LENGTH);
     });
 
     test("guarantees every input's header and first commit even when other inputs also need truncation", async () => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,6 @@
 import * as core from "@actions/core";
 import {
+    COMMENT_TAG_PATTERN,
     GITHUB_COMMENT_MAX_LENGTH,
     compareCommits,
     getFileContentAtCommit,
@@ -69,9 +70,17 @@ export async function run(): Promise<void> {
         throw new Error(`Invalid pull request number: ${prNumber}`);
     }
 
-    // Space reserved for the identity tag appended by upsertComment and a truncation notice.
-    // This covers: tag (~48 chars) + "> [!NOTE]\n> N more commit(s) ..." (~250 chars) + small buffer.
-    const COMMIT_TRUNCATION_OVERHEAD = 350;
+    // Space reserved for the identity tag appended by upsertComment, so the commit-list
+    // truncation below leaves room for it instead of relying on api.ts's blunter fallback truncation.
+    const TAG_OVERHEAD = `\n${COMMENT_TAG_PATTERN}`.length;
+
+    function buildOmittedNote(owner: string, repo: string, beforeRev: string, rev: string, count: number): string {
+        return (
+            "\n\n> [!NOTE]\n" +
+            `> ${count} more commit(s) were not shown (comment size limit). ` +
+            `[View full comparison](https://github.com/${owner}/${repo}/compare/${beforeRev}..${rev})\n`
+        );
+    }
 
     const result = ["# Flake inputs changelog"];
     core.info(`Fetching changed files for PR #${prNumber}`);
@@ -143,8 +152,15 @@ export async function run(): Promise<void> {
 
             // Track the running body size so we can truncate at commit boundaries
             // instead of cutting mid-markdown when the GitHub comment limit is approached.
+            // The reserve covers the identity tag plus the worst-case size of the omitted-commits
+            // note itself (using commits.length as the upper bound for the omitted count).
             let bodySize = result.join("\n").length;
             let omitted = 0;
+            // +1 for the newline joining the note onto `result`.
+            const reserve =
+                TAG_OVERHEAD +
+                buildOmittedNote(diff.owner, diff.repo, diff.beforeRev, diff.rev, commits.length).length +
+                1;
 
             for (let i = 0; i < commits.length; i++) {
                 const commit = commits[i];
@@ -168,7 +184,7 @@ export async function run(): Promise<void> {
                 }
 
                 // Check if adding this commit would exceed the limit.
-                if (bodySize + line.length + 1 + COMMIT_TRUNCATION_OVERHEAD > GITHUB_COMMENT_MAX_LENGTH) {
+                if (bodySize + line.length + 1 + reserve > GITHUB_COMMENT_MAX_LENGTH) {
                     omitted = commits.length - i;
                     break;
                 }
@@ -184,12 +200,7 @@ export async function run(): Promise<void> {
             await saveCacheForRepo(diff.owner, diff.repo);
 
             if (omitted > 0) {
-                result.push("");
-                result.push("> [!NOTE]");
-                result.push(
-                    `> ${omitted} more commit(s) were not shown (comment size limit). [View full comparison](https://github.com/${diff.owner}/${diff.repo}/compare/${diff.beforeRev}..${diff.rev})`,
-                );
-                result.push("");
+                result.push(buildOmittedNote(diff.owner, diff.repo, diff.beforeRev, diff.rev, omitted));
             }
         }
     }

--- a/src/main.ts
+++ b/src/main.ts
@@ -74,12 +74,57 @@ export async function run(): Promise<void> {
     // truncation below leaves room for it instead of relying on api.ts's blunter fallback truncation.
     const TAG_OVERHEAD = `\n${COMMENT_TAG_PATTERN}`.length;
 
+    function diffHeaderBlock(diff: { owner: string; repo: string; beforeRev: string; rev: string }): string {
+        return [
+            `### [${diff.owner}/${diff.repo}](https://github.com/${diff.owner}/${diff.repo})`,
+            "",
+            "<details><summary>Changelog</summary>",
+            "",
+            `[\`${diff.beforeRev}\` -> \`${diff.rev}\`](https://github.com/${diff.owner}/${diff.repo}/compare/${diff.beforeRev}..${diff.rev})`,
+        ].join("\n");
+    }
+
+    function noCommonAncestorBlock(): string {
+        return [
+            "",
+            "> [!NOTE]",
+            "> Could not generate a detailed changelog — the commits have no common ancestor. " +
+                "The repository history may have been rewritten.",
+        ].join("\n");
+    }
+
+    function closingBlock(): string {
+        return ["", "</details>", ""].join("\n");
+    }
+
     function buildOmittedNote(owner: string, repo: string, beforeRev: string, rev: string, count: number): string {
         return (
             "\n\n> [!NOTE]\n" +
             `> ${count} more commit(s) were not shown (comment size limit). ` +
             `[View full comparison](https://github.com/${owner}/${repo}/compare/${beforeRev}..${rev})\n`
         );
+    }
+
+    function commitListItem(commit: { message: string; url: string }): string {
+        // if the commit message contains a @mention, we add an unicode word joiner
+        // between @ and username, to avoid spamming the mentioned user.
+        const commitMessage = commit.message.replace(/@/g, "@\u200D");
+        const commitUrl = commit.url.replace("https://github.com", "https://redirect.github.com");
+        return `- [${commitMessage}](${commitUrl})`;
+    }
+
+    async function buildCommitLine(
+        diff: { owner: string; repo: string },
+        commit: { sha: string; message: string; url: string },
+    ): Promise<string> {
+        const item = commitListItem(commit);
+        const pr = await getPullRequestForCommit(diff.owner, diff.repo, commit.sha);
+        if (!pr) {
+            return item;
+        }
+        // use redirect.github.com instead of github.com to avoid spamming backlinks
+        const prUrl = pr.url.replace("https://github.com", "https://redirect.github.com");
+        return `${item} - [![PR Icon](https://icongr.am/octicons/git-pull-request.svg?size=14&color=abb4bf) PR #${pr.id}](${prUrl})`;
     }
 
     const result = ["# Flake inputs changelog"];
@@ -118,90 +163,95 @@ export async function run(): Promise<void> {
         }
     }
 
-    // Pass 2: full changelog generation
+    // Pass 2: gather every input's commit list (and, for the guaranteed first commit,
+    // its PR association) up front. This is what lets us know each input's exact fixed
+    // cost — header, accordion, notes — before any truncation decision is made below.
 
     // TODO cache changelogs if multiple lockfiles have the same refs and diffs
-    for (const { lockfile, diffs } of allDiffsByLockfile) {
-        result.push(`## ${lockfile}`);
+    interface GatheredDiff {
+        lockfile: string;
+        diff: LockfileDiff;
+        commits: Array<{ sha: string; message: string; url: string }>;
+        firstLine: string | null;
+    }
+    const gathered: GatheredDiff[] = [];
 
+    for (const { lockfile, diffs } of allDiffsByLockfile) {
         for (const diff of diffs) {
             core.info(`Checking ${diff.owner}/${diff.repo} ${diff.beforeRev} -> ${diff.rev}`);
-
             await restoreCacheForRepo(diff.owner, diff.repo);
-
-            result.push(`### [${diff.owner}/${diff.repo}](https://github.com/${diff.owner}/${diff.repo})`);
-
-            result.push("");
-            result.push("<details><summary>Changelog</summary>");
-            result.push("");
-
-            result.push(
-                `[\`${diff.beforeRev}\` -> \`${diff.rev}\`](https://github.com/${diff.owner}/${diff.repo}/compare/${diff.beforeRev}..${diff.rev})`,
-            );
-
             const commits = await compareCommits(diff.owner, diff.repo, diff.beforeRev, diff.rev);
+            const firstLine = commits.length > 0 ? await buildCommitLine(diff, commits[0]) : null;
+            gathered.push({ lockfile, diff, commits, firstLine });
+        }
+    }
 
-            if (commits.length === 0) {
-                result.push("");
-                result.push("> [!NOTE]");
-                result.push(
-                    "> Could not generate a detailed changelog — the commits have no common ancestor. " +
-                        "The repository history may have been rewritten.",
-                );
-            }
+    // Pass 3: reserve space for everything that isn't a discretionary commit line —
+    // the identity tag, every input's header/accordion/closing, its no-common-ancestor
+    // note if it has one, and — for inputs with commits — the guaranteed first commit
+    // line plus the worst-case omitted-commits note. This guarantees no input can be
+    // truncated down to nothing without explanation, regardless of how many other
+    // inputs are in the same comment.
+    let reserved = TAG_OVERHEAD;
+    const seenLockfiles = new Set<string>();
+    for (const { lockfile, diff, commits, firstLine } of gathered) {
+        if (!seenLockfiles.has(lockfile)) {
+            seenLockfiles.add(lockfile);
+            reserved += `## ${lockfile}`.length + 1;
+        }
+        reserved += diffHeaderBlock(diff).length + 1;
+        reserved += closingBlock().length + 1;
+        if (commits.length === 0) {
+            reserved += noCommonAncestorBlock().length + 1;
+        } else {
+            reserved += (firstLine as string).length + 1;
+            reserved += buildOmittedNote(diff.owner, diff.repo, diff.beforeRev, diff.rev, commits.length).length + 1;
+        }
+    }
+    let discretionaryBudget = Math.max(0, GITHUB_COMMENT_MAX_LENGTH - result.join("\n").length - reserved);
 
-            // Track the running body size so we can truncate at commit boundaries
-            // instead of cutting mid-markdown when the GitHub comment limit is approached.
-            // The reserve covers the identity tag plus the worst-case size of the omitted-commits
-            // note itself (using commits.length as the upper bound for the omitted count).
-            let bodySize = result.join("\n").length;
-            let omitted = 0;
-            // +1 for the newline joining the note onto `result`.
-            const reserve =
-                TAG_OVERHEAD +
-                buildOmittedNote(diff.owner, diff.repo, diff.beforeRev, diff.rev, commits.length).length +
-                1;
+    // Pass 4: render, spending the discretionary budget on extra commits per input in
+    // order. Each input's truncation point depends only on what's left after every
+    // input's fixed cost and guaranteed first commit have already been accounted for.
+    let lastLockfile: string | null = null;
+    for (const { lockfile, diff, commits, firstLine } of gathered) {
+        if (lockfile !== lastLockfile) {
+            result.push(`## ${lockfile}`);
+            lastLockfile = lockfile;
+        }
 
-            for (let i = 0; i < commits.length; i++) {
-                const commit = commits[i];
+        result.push(diffHeaderBlock(diff));
 
-                // if the commit message contains a @mention, we add an unicode word joiner
-                // between @ and username, to avoid spamming the mentioned user.
-                const commitMessage = commit.message.replace(/@/g, "@\u200D");
-                const commitUrl = commit.url.replace("https://github.com", "https://redirect.github.com");
-
-                const commitListItem = `- [${commitMessage}](${commitUrl})`;
-
-                core.info(`Checking for PRs associated with commit ${commit.sha}`);
-                const pr = await getPullRequestForCommit(diff.owner, diff.repo, commit.sha);
-                let line: string;
-                if (pr) {
-                    // use redirect.github.com instead of github.com to avoid spamming backlinks
-                    const prUrl = pr.url.replace("https://github.com", "https://redirect.github.com");
-                    line = `${commitListItem} - [![PR Icon](https://icongr.am/octicons/git-pull-request.svg?size=14&color=abb4bf) PR #${pr.id}](${prUrl})`;
-                } else {
-                    line = commitListItem;
-                }
-
-                // Check if adding this commit would exceed the limit.
-                if (bodySize + line.length + 1 + reserve > GITHUB_COMMENT_MAX_LENGTH) {
-                    omitted = commits.length - i;
-                    break;
-                }
-
-                result.push(line);
-                bodySize += line.length + 1;
-            }
-
-            result.push("");
-            result.push("</details>");
-            result.push("");
-
+        if (commits.length === 0) {
+            result.push(noCommonAncestorBlock());
+            result.push(closingBlock());
             await saveCacheForRepo(diff.owner, diff.repo);
+            continue;
+        }
 
-            if (omitted > 0) {
-                result.push(buildOmittedNote(diff.owner, diff.repo, diff.beforeRev, diff.rev, omitted));
+        result.push(firstLine as string);
+
+        let omitted = 0;
+        for (let i = 1; i < commits.length; i++) {
+            const commit = commits[i];
+            core.info(`Checking for PRs associated with commit ${commit.sha}`);
+            const line = await buildCommitLine(diff, commit);
+
+            if (line.length + 1 > discretionaryBudget) {
+                omitted = commits.length - i;
+                break;
             }
+
+            result.push(line);
+            discretionaryBudget -= line.length + 1;
+        }
+
+        result.push(closingBlock());
+
+        await saveCacheForRepo(diff.owner, diff.repo);
+
+        if (omitted > 0) {
+            result.push(buildOmittedNote(diff.owner, diff.repo, diff.beforeRev, diff.rev, omitted));
         }
     }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -133,6 +133,7 @@ export async function run(): Promise<void> {
             const commits = await compareCommits(diff.owner, diff.repo, diff.beforeRev, diff.rev);
 
             if (commits.length === 0) {
+                result.push("");
                 result.push("> [!NOTE]");
                 result.push(
                     "> Could not generate a detailed changelog — the commits have no common ancestor. " +
@@ -176,20 +177,20 @@ export async function run(): Promise<void> {
                 bodySize += line.length + 1;
             }
 
-            if (omitted > 0) {
-                result.push("");
-                result.push("> [!NOTE]");
-                result.push(
-                    `> ${omitted} more commit(s) were omitted. ` +
-                        `[View the full comparison on GitHub](https://github.com/${diff.owner}/${diff.repo}/compare/${diff.beforeRev}..${diff.rev}).`,
-                );
-            }
-
             result.push("");
             result.push("</details>");
             result.push("");
 
             await saveCacheForRepo(diff.owner, diff.repo);
+
+            if (omitted > 0) {
+                result.push("");
+                result.push("> [!NOTE]");
+                result.push(
+                    `> ${omitted} more commit(s) were not shown (comment size limit). [View full comparison](https://github.com/${diff.owner}/${diff.repo}/compare/${diff.beforeRev}..${diff.rev})`,
+                );
+                result.push("");
+            }
         }
     }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -221,8 +221,8 @@ export async function run(): Promise<void> {
         result.push(diffHeaderBlock(diff));
 
         if (commits.length === 0) {
-            result.push(noCommonAncestorBlock());
             result.push(closingBlock());
+            result.push(noCommonAncestorBlock());
             await saveCacheForRepo(diff.owner, diff.repo);
             continue;
         }

--- a/src/main.ts
+++ b/src/main.ts
@@ -166,8 +166,6 @@ export async function run(): Promise<void> {
     // Pass 2: gather every input's commit list (and, for the guaranteed first commit,
     // its PR association) up front. This is what lets us know each input's exact fixed
     // cost — header, accordion, notes — before any truncation decision is made below.
-
-    // TODO cache changelogs if multiple lockfiles have the same refs and diffs
     interface GatheredDiff {
         lockfile: string;
         diff: LockfileDiff;


### PR DESCRIPTION
Closes #292

Fixes bad admonition formatting for the "commits were skipped/omitted" and "no common ancestor" notes, per #292.

1. **Admonition syntax**: both notes now use proper GitHub admonition syntax (`> [!NOTE]` / `> [!WARNING]`) instead of a plain `> **Note:**` block, so they render as actual callouts.
2. **Visibility**: both notes are moved outside the `<details>` accordion so they're visible immediately, without needing to expand the changelog.
3. **Truncation reserve**: the space reserved for the identity tag and the omitted-commits note (used to decide how many commits to hold back so the comment stays under GitHub's 65,536-character limit) is now computed exactly from the real tag/note text instead of a hardcoded ~350-char guess.
4. **Safety net**: `upsertComment`'s fallback truncation was restored — an earlier commit on this branch had accidentally deleted it along with its tests, which would have turned "comment is a bit over the limit" into a hard failure instead of a graceful truncation.

Tests added/restored for the no-common-ancestor case, the omitted-commits case (asserting the note lands outside the accordion), and the fallback truncation in `upsertComment`.

Note: the earlier revision of this description mentioned a `compareCommits` return-type change (`{ commits, skippedCount }`) for GitHub's compare API 250-commit cap — that was a mischaracterization of this fix; #292 is about the comment-size-based truncation note, not GitHub's API cap, and no such feature is implemented here. The corresponding dead `skippedCount` field (always `0`, never read) has been removed from the cache format.