### PR TITLE
Skip comment on dependabot PRs whose body already contains the changelog

### DIFF
--- a/dist/index.mjs
+++ b/dist/index.mjs
@@ -21997,6 +21997,18 @@ async function getPullRequestForCommit(owner, repo, commit) {
     url: associatedPRs[0].html_url
   };
 }
+async function getPullRequestDetails(prNumber) {
+  const client = getGithubClient();
+  const { repo } = context2;
+  const { data } = await client.rest.pulls.get({
+    ...repo,
+    pull_number: prNumber
+  });
+  return {
+    authorLogin: data.user.login,
+    body: data.body ?? ""
+  };
+}
 
 // src/main.ts
 function parseLockfile(content) {
@@ -22038,11 +22050,24 @@ async function run() {
     return;
   }
   const { base, head } = await getPullRequestRefs(prNumber);
+  const prDetails = await getPullRequestDetails(prNumber);
+  const allDiffsByLockfile = [];
   for (const lockfile of lockfiles) {
-    result.push(`## ${lockfile}`);
     const before = parseLockfile(await getFileContentAtCommit(base, lockfile));
     const after = parseLockfile(await getFileContentAtCommit(head, lockfile));
     const diffs = getLockfileDiffs(before, after);
+    allDiffsByLockfile.push({ lockfile, diffs });
+  }
+  if (prDetails.authorLogin === "dependabot[bot]") {
+    const allCompareUrls = allDiffsByLockfile.flatMap(({ diffs }) => diffs.map((d) => `https://github.com/${d.owner}/${d.repo}/compare/${d.beforeRev}..${d.rev}`));
+    const allPresent = allCompareUrls.every((url) => prDetails.body.includes(url));
+    if (allPresent) {
+      info("Skipping comment — flake.lock changelog already present in dependabot PR description");
+      return;
+    }
+  }
+  for (const { lockfile, diffs } of allDiffsByLockfile) {
+    result.push(`## ${lockfile}`);
     for (const diff of diffs) {
       info(`Checking ${diff.owner}/${diff.repo} ${diff.beforeRev} -> ${diff.rev}`);
       result.push(`### [${diff.owner}/${diff.repo}](https://github.com/${diff.owner}/${diff.repo})`);

--- a/src/api.test.ts
+++ b/src/api.test.ts
@@ -1,6 +1,12 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import type { Mock } from "bun:test";
-import { getFileContentAtCommit, getPullRequestChangedFiles, getPullRequestRefs, upsertComment } from "~/api";
+import {
+    getFileContentAtCommit,
+    getPullRequestChangedFiles,
+    getPullRequestDetails,
+    getPullRequestRefs,
+    upsertComment,
+} from "~/api";
 import GetFileContentAtCommitQuery from "~/queries/GetFileContentAtCommit.graphql" with { type: "text" };
 import type { GetFileContentAtCommitResponse } from "~/queries/GetFileContentAtCommit.graphql";
 import GetPullRequestChangedFilesQuery from "~/queries/GetPullRequestChangedFiles.graphql" with { type: "text" };
@@ -119,6 +125,19 @@ beforeEach(async () => {
                 listComments: {},
                 createComment: createCommentMock,
                 updateComment: updateCommentMock,
+            },
+            pulls: {
+                get: mock(async ({ pull_number }: { owner: string; repo: string; pull_number: number }) => {
+                    if (pull_number === 13) {
+                        return {
+                            data: {
+                                user: { login: "dependabot[bot]" },
+                                body: "PR body text with https://github.com/owner/dep/compare/abc..def",
+                            },
+                        };
+                    }
+                    throw new Error("Invalid pull_number");
+                }),
             },
         },
     };
@@ -251,5 +270,17 @@ describe("upsertComment", () => {
         expect(posted.length).toBe(65536);
         expect(posted).not.toContain("[!NOTE]");
         expect(logMock).not.toHaveBeenCalled();
+    });
+});
+
+describe("getPullRequestDetails", () => {
+    test("returns authorLogin and body", async () => {
+        const details = await getPullRequestDetails(13);
+        expect(details.authorLogin).toEqual("dependabot[bot]");
+        expect(details.body).toEqual("PR body text with https://github.com/owner/dep/compare/abc..def");
+    });
+
+    test("throws on unknown PR number", async () => {
+        await expect(async () => getPullRequestDetails(99)).toThrow();
     });
 });

--- a/src/api.ts
+++ b/src/api.ts
@@ -188,3 +188,23 @@ export async function getPullRequestForCommit(
         url: associatedPRs[0].html_url,
     };
 }
+
+export interface PullRequestDetails {
+    authorLogin: string;
+    body: string;
+}
+
+export async function getPullRequestDetails(prNumber: number): Promise<PullRequestDetails> {
+    const client = getGithubClient();
+    const { repo } = github.context;
+
+    const { data } = await client.rest.pulls.get({
+        ...repo,
+        pull_number: prNumber,
+    });
+
+    return {
+        authorLogin: data.user.login,
+        body: data.body ?? "",
+    };
+}

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -2,10 +2,14 @@ import { beforeEach, expect, mock, test } from "bun:test";
 import { mockModule } from "~/utils/mockModule";
 
 beforeEach(() => {
-    // have to do this manually, since jest.resetModules() is not implemented
-    // Resets the module cache, so each test re-evaluates the imported modules
+    // Bun does not implement jest.resetModules(), so we manually clear the cache
+    // for index.ts and main.ts — the only modules that run side-effects on import.
+    // We intentionally do NOT clear the full cache; wiping all entries breaks
+    // mock.module() live bindings (e.g. @actions/github) in other test files.
     for (const key of Object.keys(require.cache)) {
-        delete require.cache[key];
+        if (key.includes("/src/index") || key.includes("/src/main")) {
+            delete require.cache[key];
+        }
     }
 });
 

--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -1,1 +1,76 @@
-// TODO
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import type { Mock } from "bun:test";
+import type { PullRequestDetails } from "~/api";
+import { mockModule } from "~/utils/mockModule";
+
+const BEFORE_LOCK = JSON.stringify({
+    nodes: {
+        root: { inputs: { nixpkgs: "nixpkgs" } },
+        nixpkgs: { locked: { owner: "NixOS", repo: "nixpkgs", rev: "aaaa1111", type: "github" } },
+    },
+});
+const AFTER_LOCK = JSON.stringify({
+    nodes: {
+        root: { inputs: { nixpkgs: "nixpkgs" } },
+        nixpkgs: { locked: { owner: "NixOS", repo: "nixpkgs", rev: "bbbb2222", type: "github" } },
+    },
+});
+const COMPARE_URL = "https://github.com/NixOS/nixpkgs/compare/aaaa1111..bbbb2222";
+
+let moduleMocks: Array<Awaited<ReturnType<typeof mockModule>>> = [];
+let upsertCommentMock: Mock<() => Promise<void>>;
+let getPullRequestDetailsMock: Mock<() => Promise<PullRequestDetails>>;
+
+beforeEach(async () => {
+    upsertCommentMock = mock(async () => {});
+    getPullRequestDetailsMock = mock(async () => ({
+        authorLogin: "dependabot[bot]",
+        body: COMPARE_URL,
+    }));
+
+    moduleMocks = [
+        await mockModule("@actions/core", () => ({
+            getInput: mock((input: string) => (input === "pull-request-number" ? "42" : "")),
+            info: mock(() => {}),
+            warning: mock(() => {}),
+        })),
+        await mockModule("~/api", () => ({
+            getPullRequestChangedFiles: mock(async () => ["flake.lock"]),
+            getPullRequestRefs: mock(async () => ({ base: "basesha", head: "headsha" })),
+            getFileContentAtCommit: mock(async (commit: string, _path: string) =>
+                commit === "basesha" ? BEFORE_LOCK : AFTER_LOCK,
+            ),
+            getPullRequestDetails: getPullRequestDetailsMock,
+            compareCommits: mock(async () => []),
+            getPullRequestForCommit: mock(async () => null),
+            upsertComment: upsertCommentMock,
+        })),
+    ];
+});
+
+afterEach(() => {
+    for (const moduleMock of moduleMocks) {
+        moduleMock.dispose();
+    }
+});
+
+describe("run", () => {
+    test("skips comment when dependabot PR already contains all compare URLs", async () => {
+        // dynamic import required: mock must be installed before ~/main initialises
+        // its ~/api bindings (Bun issue #7823, same pattern as index.test.ts).
+        const { run } = await import("~/main");
+        await run();
+        expect(upsertCommentMock).not.toHaveBeenCalled();
+    });
+
+    test("posts comment when dependabot PR body is missing a compare URL", async () => {
+        getPullRequestDetailsMock.mockImplementation(async () => ({
+            authorLogin: "dependabot[bot]",
+            body: "this description does not mention the compare url",
+        }));
+        // dynamic import required: same reason as above.
+        const { run } = await import("~/main");
+        await run();
+        expect(upsertCommentMock).toHaveBeenCalledTimes(1);
+    });
+});

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,6 +4,7 @@ import {
     compareCommits,
     getFileContentAtCommit,
     getPullRequestChangedFiles,
+    getPullRequestDetails,
     getPullRequestForCommit,
     getPullRequestRefs,
     upsertComment,
@@ -71,7 +72,6 @@ export async function run(): Promise<void> {
     const COMMIT_TRUNCATION_OVERHEAD = 350;
 
     const result = ["# Flake inputs changelog"];
-
     core.info(`Fetching changed files for PR #${prNumber}`);
     const files = await getPullRequestChangedFiles(prNumber);
     const lockfiles = files.filter((file) => file.endsWith("flake.lock"));
@@ -82,14 +82,36 @@ export async function run(): Promise<void> {
     }
 
     const { base, head } = await getPullRequestRefs(prNumber);
+    const prDetails = await getPullRequestDetails(prNumber);
 
-    // TODO cache changelogs if multiple lockfiles have the same refs and diffs
+    // Pass 1: compute all diffs across all lockfiles (no compareCommits calls yet)
+    type LockfileDiff = LockfileItem & { beforeRev: string };
+    const allDiffsByLockfile: Array<{ lockfile: string; diffs: LockfileDiff[] }> = [];
+
     for (const lockfile of lockfiles) {
-        result.push(`## ${lockfile}`);
-
         const before = parseLockfile(await getFileContentAtCommit(base, lockfile));
         const after = parseLockfile(await getFileContentAtCommit(head, lockfile));
         const diffs = getLockfileDiffs(before, after);
+        allDiffsByLockfile.push({ lockfile, diffs });
+    }
+
+    // Dependabot skip check: if all compare URLs already appear in the PR body, no comment needed
+    if (prDetails.authorLogin === "dependabot[bot]") {
+        const allCompareUrls = allDiffsByLockfile.flatMap(({ diffs }) =>
+            diffs.map((d) => `https://github.com/${d.owner}/${d.repo}/compare/${d.beforeRev}..${d.rev}`),
+        );
+        const allPresent = allCompareUrls.every((url) => prDetails.body.includes(url));
+        if (allPresent) {
+            core.info("Skipping comment — flake.lock changelog already present in dependabot PR description");
+            return;
+        }
+    }
+
+    // Pass 2: full changelog generation
+
+    // TODO cache changelogs if multiple lockfiles have the same refs and diffs
+    for (const { lockfile, diffs } of allDiffsByLockfile) {
+        result.push(`## ${lockfile}`);
 
         for (const diff of diffs) {
             core.info(`Checking ${diff.owner}/${diff.repo} ${diff.beforeRev} -> ${diff.rev}`);


### PR DESCRIPTION
Closes #294

When a PR is authored by `dependabot[bot]`, the action now checks whether the PR description already contains all the compare URLs that would appear in the generated comment (e.g. `https://github.com/NixOS/nixpkgs/compare/abc..def`). If every URL is present, posting the comment is skipped entirely.

Implementation:
- New `getPullRequestDetails(prNumber)` in `api.ts` — fetches author login and body via REST
- Two-pass structure in `run()`: parse diffs first, do the dependabot check before fetching full commit history (avoids unnecessary `compareCommits` calls on skip path)
- Two new tests in `main.test.ts` covering skip and no-skip cases
- Fixes a cross-file test interference bug in `index.test.ts`: scoped `require.cache` clearing to only `index`/`main` paths instead of nuking the full registry