### PR TITLE
Add build-filter: bisect changelog commits by build relevance

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,63 +52,19 @@ jobs:
 
 ## Build filter
 
-By default, every upstream commit between the old and new `rev` of a flake input is listed in the
-changelog. For inputs like `nixpkgs`, most commits don't actually change anything that the flake
-depends on (docs, unrelated packages, CI, etc.), which makes the changelog noisy. Setting
-`build-filter` runs a build at a subset of the upstream commits and hides commits that didn't
-change the build output behind a collapsed "did not affect the build output" section.
+Not every upstream commit in a `flake.lock` bump actually changes what gets built — a `nixpkgs`
+update, for example, usually drags in a lot of commits that only touch docs, unrelated packages, or
+CI. Setting `build-filter` builds your flake at a handful of commits in the range and tucks the
+commits that turned out not to affect the build output into a collapsed "did not affect the build
+output" section, so the changelog highlights what actually matters.
 
-### How it works
+`build-filter` is a shell command that the action runs at various upstream commits and whose output
+it uses to tell "the build changed" from "the build didn't change". It's evaluated once per changed
+input (so the same command applies to `nixpkgs`, `flake-utils`, or any other input in your lockfile
+— see [environment variables](#environment-variables) below), and it only runs at a handful of
+commits per input, not every commit in the range, so it stays cheap even for large ranges.
 
-For **each** flake input that changed in the lockfile (not just `nixpkgs`), the action:
-
-1. Clones the input's upstream repository with `--filter=blob:none` (a blobless clone — cheap on
-   bandwidth since blobs are fetched lazily on checkout).
-2. Runs your `build-filter` command at the **first and last** commit of the range only.
-   - If the two outputs are identical, every commit in between is marked irrelevant — 2 builds
-     total, no further work needed.
-3. If the outputs differ, the action **bisects** the range: it builds the midpoint commit, compares
-   its output to both ends, and recurses only into the sub-ranges whose endpoints disagree. Ranges
-   whose endpoints already agree are skipped entirely.
-
-This costs O(k log n) builds, where `n` is the number of commits in the range and `k` is the number
-of times the output actually changes — versus O(n) for a naive linear scan. Worst case (every
-commit changes the output) is still bounded at ~2n builds; best case (no commit matters) is 2
-builds regardless of range size.
-
-Because the algorithm only compares the *build output*, not the diff, it works even when the
-relationship between commit content and build output isn't obvious — e.g. it correctly ignores
-reverts, commits that touch the source but not any derivation actually used, or refactors that
-don't change what gets built.
-
-### What your `build-filter` command must output
-
-The command is run once per commit that the bisection needs to inspect. Its **stdout** is treated
-as an opaque fingerprint of the build for that commit — the action never inspects its meaning,
-only compares it for equality between commits. It should be:
-
-- **Deterministic** for a given commit — the same commit must always produce the same fingerprint,
-  otherwise the bisection will produce inconsistent (and possibly contradictory) results.
-- **Sensitive to build-relevant changes, and only those** — it should change whenever something a
-  consumer of the flake would care about changes (e.g. a package's contents or version), and stay
-  the same otherwise (e.g. ignore embedded timestamps or build-machine-specific paths).
-- A single line is enough; a Nix store path (e.g. the output of `nix build --print-out-paths`) or a
-  content hash both work well.
-
-A non-zero exit code from the command is treated as a failure of the whole build-filter step for
-that input: the action logs a warning and falls back to showing every commit for that input
-unfiltered, rather than guessing.
-
-### Environment variables
-
-The command runs as-is (no extra Nix flags are injected) in the Actions workspace — the same
-directory your workflow already checked out — with these variables set:
-
-| Variable | Description |
-| :-- | :-- |
-| `CFLC_INPUT_NAME` | The name of the flake input being tested, e.g. `nixpkgs`. Use this instead of hardcoding an input name so the same command works for **every** input that changed, not just one. |
-| `CFLC_INPUT_PATH` | Path to the upstream checkout, at the commit currently being tested. |
-| `CFLC_INPUT_REV` | The commit SHA currently checked out at `CFLC_INPUT_PATH`. |
+### Example usage
 
 ```yaml
 - uses: mdarocha/comment-flake-lock-changelog@main
@@ -117,18 +73,45 @@ directory your workflow already checked out — with these variables set:
     build-filter: 'nix build --override-input "$CFLC_INPUT_NAME" "path:$CFLC_INPUT_PATH" --print-out-paths'
 ```
 
-Using `$CFLC_INPUT_NAME` lets one `build-filter` command handle every input in the lockfile. A
-command that hardcodes a single input name (e.g. always `--override-input nixpkgs ...`) will
-silently override the wrong input whenever a *different* input's history is being bisected, which
-gives meaningless or broken build results for that input.
+This overrides whichever input is currently being tested with the upstream checkout at the commit
+being tested, builds it, and prints the resulting store path — which the action uses as the
+fingerprint for that commit.
 
-### A note on inputs that change together
+### Environment variables
 
-When a PR updates multiple inputs at once, each input's commit range is bisected independently, and
-the build for input A is always run against the **other** inputs pinned at their final (post-update)
-versions — not their pre-update versions. This mirrors what the flake will actually build with once
-the whole PR is merged, so it's the right comparison for "does this commit matter for my final flake
-output". It does mean that if two inputs' updates are entangled (e.g. a `nixpkgs` bump that only
-builds because a `flake-utils` bump also landed), bisecting `nixpkgs` alone won't observe an
-inconsistent intermediate state — the other input is never rolled back, so the fingerprint
-differences you see are attributable to the input actually being bisected.
+| Variable | Description |
+| :-- | :-- |
+| `CFLC_INPUT_NAME` | The name of the flake input being tested, e.g. `nixpkgs`. Use it instead of hardcoding an input name in your command, so the same `build-filter` works for every input in the lockfile. |
+| `CFLC_INPUT_PATH` | Path to the upstream checkout, at the commit currently being tested. |
+| `CFLC_INPUT_REV` | The commit SHA currently checked out at `CFLC_INPUT_PATH`. |
+
+### What your command should output
+
+The action treats your command's **stdout** as an opaque fingerprint — it doesn't inspect what the
+value means, it just compares it between commits. For that comparison to be meaningful, the output
+should be:
+
+- **Deterministic** — the same commit should always produce the same fingerprint.
+- **Sensitive to changes that matter, and nothing else** — it should change whenever something a
+  consumer of your flake would actually notice changes (a package version, its contents, ...), and
+  stay stable otherwise (ignore embedded timestamps, build-machine-specific paths, etc.).
+
+If the command exits non-zero, the action logs a warning and falls back to showing every commit for
+that input, unfiltered, rather than guessing.
+
+> [!TIP]
+> Prefer a **change sentinel** over a full build where you can. A Nix output path (like
+> `--print-out-paths` above) is already a fingerprint of the *entire* dependency closure that went
+> into it — you don't need to wait for `nix build` to finish compiling anything to get it. Something
+> like `nix eval --raw ".#packages.<system>.default.drvPath"` (or `outPath`) computes the same
+> fingerprint through evaluation alone, without building, which is typically instant even for large
+> packages. Reach for an actual `nix build` only if you need to inspect the built result itself (for
+> example, to fingerprint a specific file inside the output) rather than just detect that something
+> changed.
+
+### Inputs that change together
+
+If a PR bumps more than one input, each input is tested independently, with every *other* input held
+at its new (post-update) version for the duration. In other words, testing `nixpkgs` always happens
+against the `flake-utils` version your PR is updating *to*, never the one it's updating *from* — so
+you're seeing the same build your flake will actually produce once the whole PR lands.

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ This action is meant to be used as a helper to [update-flake-lock](https://githu
 | :-- | :-- | :-- |
 | `pull-request-number` | Id of the PR that will be analyzed by the action | none, **required** |
 | `token` | Token used for authentication with Github API | `${{ github.token }}` |
+| `build-filter` | Shell command to run at each upstream commit to determine build relevance. See [Build filter](#build-filter) below. | none |
 
 ## Example usage
 
@@ -48,3 +49,86 @@ jobs:
 ## Example result
 
 ![image](https://github.com/user-attachments/assets/f6a2217f-3d44-462b-a9c9-a1393206369e)
+
+## Build filter
+
+By default, every upstream commit between the old and new `rev` of a flake input is listed in the
+changelog. For inputs like `nixpkgs`, most commits don't actually change anything that the flake
+depends on (docs, unrelated packages, CI, etc.), which makes the changelog noisy. Setting
+`build-filter` runs a build at a subset of the upstream commits and hides commits that didn't
+change the build output behind a collapsed "did not affect the build output" section.
+
+### How it works
+
+For **each** flake input that changed in the lockfile (not just `nixpkgs`), the action:
+
+1. Clones the input's upstream repository with `--filter=blob:none` (a blobless clone — cheap on
+   bandwidth since blobs are fetched lazily on checkout).
+2. Runs your `build-filter` command at the **first and last** commit of the range only.
+   - If the two outputs are identical, every commit in between is marked irrelevant — 2 builds
+     total, no further work needed.
+3. If the outputs differ, the action **bisects** the range: it builds the midpoint commit, compares
+   its output to both ends, and recurses only into the sub-ranges whose endpoints disagree. Ranges
+   whose endpoints already agree are skipped entirely.
+
+This costs O(k log n) builds, where `n` is the number of commits in the range and `k` is the number
+of times the output actually changes — versus O(n) for a naive linear scan. Worst case (every
+commit changes the output) is still bounded at ~2n builds; best case (no commit matters) is 2
+builds regardless of range size.
+
+Because the algorithm only compares the *build output*, not the diff, it works even when the
+relationship between commit content and build output isn't obvious — e.g. it correctly ignores
+reverts, commits that touch the source but not any derivation actually used, or refactors that
+don't change what gets built.
+
+### What your `build-filter` command must output
+
+The command is run once per commit that the bisection needs to inspect. Its **stdout** is treated
+as an opaque fingerprint of the build for that commit — the action never inspects its meaning,
+only compares it for equality between commits. It should be:
+
+- **Deterministic** for a given commit — the same commit must always produce the same fingerprint,
+  otherwise the bisection will produce inconsistent (and possibly contradictory) results.
+- **Sensitive to build-relevant changes, and only those** — it should change whenever something a
+  consumer of the flake would care about changes (e.g. a package's contents or version), and stay
+  the same otherwise (e.g. ignore embedded timestamps or build-machine-specific paths).
+- A single line is enough; a Nix store path (e.g. the output of `nix build --print-out-paths`) or a
+  content hash both work well.
+
+A non-zero exit code from the command is treated as a failure of the whole build-filter step for
+that input: the action logs a warning and falls back to showing every commit for that input
+unfiltered, rather than guessing.
+
+### Environment variables
+
+The command runs as-is (no extra Nix flags are injected) in the Actions workspace — the same
+directory your workflow already checked out — with these variables set:
+
+| Variable | Description |
+| :-- | :-- |
+| `CFLC_INPUT_NAME` | The name of the flake input being tested, e.g. `nixpkgs`. Use this instead of hardcoding an input name so the same command works for **every** input that changed, not just one. |
+| `CFLC_INPUT_PATH` | Path to the upstream checkout, at the commit currently being tested. |
+| `CFLC_INPUT_REV` | The commit SHA currently checked out at `CFLC_INPUT_PATH`. |
+
+```yaml
+- uses: mdarocha/comment-flake-lock-changelog@main
+  with:
+    pull-request-number: ${{ github.event.pull_request.number }}
+    build-filter: 'nix build --override-input "$CFLC_INPUT_NAME" "path:$CFLC_INPUT_PATH" --print-out-paths'
+```
+
+Using `$CFLC_INPUT_NAME` lets one `build-filter` command handle every input in the lockfile. A
+command that hardcodes a single input name (e.g. always `--override-input nixpkgs ...`) will
+silently override the wrong input whenever a *different* input's history is being bisected, which
+gives meaningless or broken build results for that input.
+
+### A note on inputs that change together
+
+When a PR updates multiple inputs at once, each input's commit range is bisected independently, and
+the build for input A is always run against the **other** inputs pinned at their final (post-update)
+versions — not their pre-update versions. This mirrors what the flake will actually build with once
+the whole PR is merged, so it's the right comparison for "does this commit matter for my final flake
+output". It does mean that if two inputs' updates are entangled (e.g. a `nixpkgs` bump that only
+builds because a `flake-utils` bump also landed), bisecting `nixpkgs` alone won't observe an
+inconsistent intermediate state — the other input is never rolled back, so the fingerprint
+differences you see are attributable to the input actually being bisected.

--- a/README.md
+++ b/README.md
@@ -108,6 +108,14 @@ that input, unfiltered, rather than guessing.
 > packages. Reach for an actual `nix build` only if you need to inspect the built result itself (for
 > example, to fingerprint a specific file inside the output) rather than just detect that something
 > changed.
+>
+> Keep unrelated changes out of the sentinel, or every commit will look "relevant" even when nothing
+> you use actually changed. Point it at the specific output you care about (e.g.
+> `packages.<system>.default`) instead of something broad like all of nixpkgs — that way doc and
+> manual updates elsewhere in the tree never enter your dependency closure in the first place. And
+> avoid anything that deliberately stamps the exact commit into the output, like a NixOS config's
+> `system.nixos.revision` set from `self.rev` — that changes on every single commit by design, which
+> defeats the filter entirely.
 
 ### Inputs that change together
 

--- a/action.yml
+++ b/action.yml
@@ -12,7 +12,7 @@ inputs:
     required: false
     default: ${{ github.token }}
   build-filter:
-    description: "When set, run this shell command at each upstream commit to determine build relevance. The command receives CFLC_INPUT_NAME (the flake input's name, e.g. `nixpkgs`), CFLC_INPUT_PATH (path to the upstream checkout), and CFLC_INPUT_REV (commit SHA) as environment variables, so one command can support every input in the lockfile, not just a single hardcoded one. Its stdout is used as a build fingerprint — commits that change the output are marked relevant. Requires git in PATH."
+    description: "Shell command that builds your flake, used to hide changelog commits that don't affect the build output. See the README's 'Build filter' section for details."
     required: false
     default: ""
 runs:

--- a/action.yml
+++ b/action.yml
@@ -11,6 +11,14 @@ inputs:
     description: "GITHUB_TOKEN or a `repo` scoped Personal Access Token (PAT)"
     required: false
     default: ${{ github.token }}
+  build-filter:
+    description: "When set, run this shell command at each upstream commit to filter the changelog into relevant/irrelevant commits. Requires nix and git in PATH. E.g. 'nix build .#myPackage'."
+    required: false
+    default: ""
+  build-filter-input:
+    description: "The flake input name to override during build-filter (e.g. 'nixpkgs'). Required when build-filter is set."
+    required: false
+    default: ""
 runs:
   using: node20
   main: dist/index.mjs

--- a/action.yml
+++ b/action.yml
@@ -12,11 +12,7 @@ inputs:
     required: false
     default: ${{ github.token }}
   build-filter:
-    description: "When set, run this shell command at each upstream commit to filter the changelog into relevant/irrelevant commits. Requires nix and git in PATH. E.g. 'nix build .#myPackage'."
-    required: false
-    default: ""
-  build-filter-input:
-    description: "The flake input name to override during build-filter (e.g. 'nixpkgs'). Required when build-filter is set."
+    description: "When set, run this shell command at each upstream commit to determine build relevance. The command receives CFLC_INPUT_PATH (path to the upstream checkout) and CFLC_INPUT_REV (commit SHA) as environment variables. Its stdout is used as a build fingerprint — commits that change the output are marked relevant. Requires git in PATH."
     required: false
     default: ""
 runs:

--- a/action.yml
+++ b/action.yml
@@ -12,7 +12,7 @@ inputs:
     required: false
     default: ${{ github.token }}
   build-filter:
-    description: "When set, run this shell command at each upstream commit to determine build relevance. The command receives CFLC_INPUT_PATH (path to the upstream checkout) and CFLC_INPUT_REV (commit SHA) as environment variables. Its stdout is used as a build fingerprint — commits that change the output are marked relevant. Requires git in PATH."
+    description: "When set, run this shell command at each upstream commit to determine build relevance. The command receives CFLC_INPUT_NAME (the flake input's name, e.g. `nixpkgs`), CFLC_INPUT_PATH (path to the upstream checkout), and CFLC_INPUT_REV (commit SHA) as environment variables, so one command can support every input in the lockfile, not just a single hardcoded one. Its stdout is used as a build fingerprint — commits that change the output are marked relevant. Requires git in PATH."
     required: false
     default: ""
 runs:

--- a/dist/index.mjs
+++ b/dist/index.mjs
@@ -66663,6 +66663,74 @@ async function saveCacheForRepo(owner, repo) {
   }
 }
 
+// src/buildFilter.ts
+import * as fs2 from "fs";
+import { spawnSync } from "node:child_process";
+import * as os4 from "os";
+import * as path from "path";
+function spawnCmd(cmd, opts) {
+  const result = spawnSync(cmd[0], cmd.slice(1), {
+    ...opts?.cwd !== undefined ? { cwd: opts.cwd } : {},
+    encoding: "utf8"
+  });
+  return {
+    stdout: result.stdout ?? "",
+    stderr: result.stderr ?? "",
+    exitCode: result.status ?? 1
+  };
+}
+function checkToolAvailable(tool) {
+  const result = spawnCmd(["which", tool]);
+  return result.exitCode === 0;
+}
+function buildAtPath(repoPath, buildCommand, inputName) {
+  const fullCommand = `${buildCommand} --override-input ${inputName} path:${repoPath} --no-link --print-out-paths`;
+  const result = spawnCmd(["sh", "-c", fullCommand]);
+  if (result.exitCode !== 0) {
+    throw new Error(`Build failed: ${result.stderr}`);
+  }
+  return result.stdout.trim();
+}
+async function filterCommitsByBuildRelevance(commits, diff, buildCommand, inputName) {
+  if (!checkToolAvailable("git")) {
+    throw new Error("git not found in PATH — cannot run build-filter");
+  }
+  if (!checkToolAvailable("nix")) {
+    throw new Error("nix not found in PATH — cannot run build-filter");
+  }
+  const tmpDir = fs2.mkdtempSync(path.join(os4.tmpdir(), "cflc-"));
+  try {
+    const repoPath = path.join(tmpDir, "repo");
+    const repoUrl = `https://github.com/${diff.owner}/${diff.repo}`;
+    const cloneResult = spawnCmd(["git", "clone", "--filter=blob:none", "--no-checkout", repoUrl, repoPath]);
+    if (cloneResult.exitCode !== 0) {
+      throw new Error(`Failed to clone ${repoUrl}: ${cloneResult.stderr}`);
+    }
+    const allShas = [diff.beforeRev, ...commits.map((c) => c.sha)];
+    const outputs = [];
+    for (const sha of allShas) {
+      const checkoutResult = spawnCmd(["git", "checkout", sha], { cwd: repoPath });
+      if (checkoutResult.exitCode !== 0) {
+        throw new Error(`git checkout ${sha} failed: ${checkoutResult.stderr}`);
+      }
+      const output = buildAtPath(repoPath, buildCommand, inputName);
+      outputs.push(output);
+    }
+    const relevant = [];
+    const irrelevant = [];
+    for (let i = 0;i < commits.length; i++) {
+      if (outputs[i + 1] !== outputs[i]) {
+        relevant.push(commits[i]);
+      } else {
+        irrelevant.push(commits[i]);
+      }
+    }
+    return { relevant, irrelevant };
+  } finally {
+    fs2.rmSync(tmpDir, { recursive: true, force: true });
+  }
+}
+
 // src/main.ts
 function parseLockfile(content) {
   if (content === "") {
@@ -66688,12 +66756,27 @@ function getLockfileDiffs(before, after) {
     beforeRev: before[key].rev
   }));
 }
+async function renderCommitListItem(result, owner, repo, commit) {
+  info(`Checking for PRs associated with commit ${commit.sha}`);
+  const commitMessage = commit.message.replace(/@/g, "@‍");
+  const commitUrl = commit.url.replace("https://github.com", "https://redirect.github.com");
+  const commitListItem = `- [${commitMessage}](${commitUrl})`;
+  const pr = await getPullRequestForCommit(owner, repo, commit.sha);
+  if (pr) {
+    const prUrl = pr.url.replace("https://github.com", "https://redirect.github.com");
+    result.push(`${commitListItem} - [![PR Icon](https://icongr.am/octicons/git-pull-request.svg?size=14&color=abb4bf) PR #${pr.id}](${prUrl})`);
+  } else {
+    result.push(commitListItem);
+  }
+}
 async function run() {
   const prNumber = Number(getInput("pull-request-number"));
   if (isNaN(prNumber) || prNumber === 0) {
     throw new Error(`Invalid pull request number: ${prNumber}`);
   }
   const COMMIT_TRUNCATION_OVERHEAD = 350;
+  const buildFilter = getInput("build-filter");
+  const buildFilterInput = getInput("build-filter-input");
   const result = ["# Flake inputs changelog"];
   info(`Fetching changed files for PR #${prNumber}`);
   const files = await getPullRequestChangedFiles(prNumber);
@@ -66737,26 +66820,57 @@ async function run() {
       let bodySize = result.join(`
 `).length;
       let omitted = 0;
-      for (let i = 0;i < commits.length; i++) {
-        const commit = commits[i];
-        const commitMessage = commit.message.replace(/@/g, "@‍");
-        const commitUrl = commit.url.replace("https://github.com", "https://redirect.github.com");
-        const commitListItem = `- [${commitMessage}](${commitUrl})`;
-        info(`Checking for PRs associated with commit ${commit.sha}`);
-        const pr = await getPullRequestForCommit(diff.owner, diff.repo, commit.sha);
-        let line;
-        if (pr) {
-          const prUrl = pr.url.replace("https://github.com", "https://redirect.github.com");
-          line = `${commitListItem} - [![PR Icon](https://icongr.am/octicons/git-pull-request.svg?size=14&color=abb4bf) PR #${pr.id}](${prUrl})`;
-        } else {
-          line = commitListItem;
+      if (buildFilter && buildFilterInput && commits.length > 0) {
+        info(`Running build-filter for ${diff.owner}/${diff.repo}`);
+        let relevant = commits;
+        let irrelevant = [];
+        try {
+          const filtered = await filterCommitsByBuildRelevance(commits, diff, buildFilter, buildFilterInput);
+          relevant = filtered.relevant;
+          irrelevant = filtered.irrelevant;
+        } catch (e) {
+          warning(`build-filter failed: ${e}. Showing all commits.`);
         }
-        if (bodySize + line.length + 1 + COMMIT_TRUNCATION_OVERHEAD > GITHUB_COMMENT_MAX_LENGTH) {
-          omitted = commits.length - i;
-          break;
+        if (relevant.length === 0) {
+          result.push("");
+          result.push("> [!NOTE]");
+          result.push("> All commits in this range produced identical build output.");
         }
-        result.push(line);
-        bodySize += line.length + 1;
+        for (const commit of relevant) {
+          await renderCommitListItem(result, diff.owner, diff.repo, commit);
+        }
+        if (irrelevant.length > 0) {
+          result.push("");
+          result.push(`<details><summary>${irrelevant.length} commit${irrelevant.length === 1 ? "" : "s"} that did not affect the build output</summary>`);
+          result.push("");
+          for (const commit of irrelevant) {
+            await renderCommitListItem(result, diff.owner, diff.repo, commit);
+          }
+          result.push("");
+          result.push("</details>");
+        }
+      } else {
+        for (let i = 0;i < commits.length; i++) {
+          const commit = commits[i];
+          const commitMessage = commit.message.replace(/@/g, "@‍");
+          const commitUrl = commit.url.replace("https://github.com", "https://redirect.github.com");
+          const commitListItem = `- [${commitMessage}](${commitUrl})`;
+          info(`Checking for PRs associated with commit ${commit.sha}`);
+          const pr = await getPullRequestForCommit(diff.owner, diff.repo, commit.sha);
+          let line;
+          if (pr) {
+            const prUrl = pr.url.replace("https://github.com", "https://redirect.github.com");
+            line = `${commitListItem} - [![PR Icon](https://icongr.am/octicons/git-pull-request.svg?size=14&color=abb4bf) PR #${pr.id}](${prUrl})`;
+          } else {
+            line = commitListItem;
+          }
+          if (bodySize + line.length + 1 + COMMIT_TRUNCATION_OVERHEAD > GITHUB_COMMENT_MAX_LENGTH) {
+            omitted = commits.length - i;
+            break;
+          }
+          result.push(line);
+          bodySize += line.length + 1;
+        }
       }
       if (omitted > 0) {
         result.push("");

--- a/dist/index.mjs
+++ b/dist/index.mjs
@@ -66700,7 +66700,12 @@ function filterCommitsByBuildRelevance(commits, diff, buildCommand) {
       }
       const result = spawnCmd(cmdParts, {
         cwd: process.cwd(),
-        env: { ...process.env, CFLC_INPUT_PATH: repoPath, CFLC_INPUT_REV: sha }
+        env: {
+          ...process.env,
+          CFLC_INPUT_NAME: diff.name,
+          CFLC_INPUT_PATH: repoPath,
+          CFLC_INPUT_REV: sha
+        }
       });
       if (result.exitCode !== 0) {
         throw new Error(`Build command failed at ${sha}: ${result.stderr}`);
@@ -66750,7 +66755,8 @@ function parseLockfile(content) {
 function getLockfileDiffs(before, after) {
   return Object.entries(after).filter(([_key, value]) => value.type === "github").filter(([key, value]) => before[key] && before[key].rev && before[key].rev !== value.rev).map(([key, value]) => ({
     ...value,
-    beforeRev: before[key].rev
+    beforeRev: before[key].rev,
+    name: key
   }));
 }
 async function renderCommitListItem(result, owner, repo, commit) {

--- a/dist/index.mjs
+++ b/dist/index.mjs
@@ -66536,32 +66536,11 @@ async function compareCommits(owner, repo, base, head) {
 var LEGACY_COMMENT_TAG_PATTERN = `<!-- thollander/actions-comment-pull-request "comment-flake-lock-changelog" -->`;
 var COMMENT_TAG_PATTERN = `<!-- mdarocha/comment-flake-lock-changelog -->`;
 var GITHUB_COMMENT_MAX_LENGTH = 65536;
-var TRUNCATION_NOTICE = `
-
-> [!NOTE]
-> The changelog was truncated because it exceeded GitHub's maximum comment size of 65,536 characters.`;
-function buildCommentBody(body2) {
-  const tag = `
-${COMMENT_TAG_PATTERN}`;
-  const full = `${body2}${tag}`;
-  if (full.length <= GITHUB_COMMENT_MAX_LENGTH) {
-    return full;
-  }
-  const available = GITHUB_COMMENT_MAX_LENGTH - tag.length - TRUNCATION_NOTICE.length;
-  const cutIndex = body2.lastIndexOf(`
-`, available);
-  const safeBody = cutIndex > 0 ? body2.slice(0, cutIndex) : body2.slice(0, available);
-  return `${safeBody}${TRUNCATION_NOTICE}${tag}`;
-}
 async function upsertComment(prNumber, body2) {
   const client = getGithubClient();
   const { repo } = context4;
-  const wouldExceed = `${body2}
-${COMMENT_TAG_PATTERN}`.length > GITHUB_COMMENT_MAX_LENGTH;
-  if (wouldExceed) {
-    warning("Comment body exceeded GitHub's maximum comment size of 65,536 characters and was truncated.");
-  }
-  const taggedBody = buildCommentBody(body2);
+  const taggedBody = `${body2}
+${COMMENT_TAG_PATTERN}`;
   function hasCommentTag(comment) {
     return comment?.body?.includes(COMMENT_TAG_PATTERN) === true || comment?.body?.includes(LEGACY_COMMENT_TAG_PATTERN) === true;
   }
@@ -66664,13 +66643,14 @@ async function saveCacheForRepo(owner, repo) {
 }
 
 // src/buildFilter.ts
-import * as fs2 from "fs";
+import * as fs8 from "fs";
 import { spawnSync } from "node:child_process";
-import * as os4 from "os";
-import * as path from "path";
+import * as os8 from "os";
+import * as path12 from "path";
 function spawnCmd(cmd, opts) {
   const result = spawnSync(cmd[0], cmd.slice(1), {
     ...opts?.cwd !== undefined ? { cwd: opts.cwd } : {},
+    ...opts?.env !== undefined ? { env: opts.env } : {},
     encoding: "utf8"
   });
   return {
@@ -66683,43 +66663,60 @@ function checkToolAvailable(tool) {
   const result = spawnCmd(["which", tool]);
   return result.exitCode === 0;
 }
-function buildAtPath(repoPath, buildCommand, inputName) {
-  const fullCommand = `${buildCommand} --override-input ${inputName} path:${repoPath} --no-link --print-out-paths`;
-  const result = spawnCmd(["sh", "-c", fullCommand]);
-  if (result.exitCode !== 0) {
-    throw new Error(`Build failed: ${result.stderr}`);
+function bisect(lo, hi, outLo, outHi, allShas, outputs, buildFn) {
+  if (outLo === outHi) {
+    for (let i = lo + 1;i <= hi; i++)
+      outputs.set(i, outLo);
+    return;
   }
-  return result.stdout.trim();
+  if (hi - lo === 1) {
+    outputs.set(hi, outHi);
+    return;
+  }
+  const mid = Math.floor((lo + hi) / 2);
+  const outMid = buildFn(allShas[mid]);
+  outputs.set(mid, outMid);
+  bisect(lo, mid, outLo, outMid, allShas, outputs, buildFn);
+  bisect(mid, hi, outMid, outHi, allShas, outputs, buildFn);
 }
-async function filterCommitsByBuildRelevance(commits, diff, buildCommand, inputName) {
+function filterCommitsByBuildRelevance(commits, diff, buildCommand) {
   if (!checkToolAvailable("git")) {
     throw new Error("git not found in PATH — cannot run build-filter");
   }
-  if (!checkToolAvailable("nix")) {
-    throw new Error("nix not found in PATH — cannot run build-filter");
-  }
-  const tmpDir = fs2.mkdtempSync(path.join(os4.tmpdir(), "cflc-"));
+  const tmpDir = fs8.mkdtempSync(path12.join(os8.tmpdir(), "cflc-"));
   try {
-    const repoPath = path.join(tmpDir, "repo");
+    const repoPath = path12.join(tmpDir, "repo");
     const repoUrl = `https://github.com/${diff.owner}/${diff.repo}`;
     const cloneResult = spawnCmd(["git", "clone", "--filter=blob:none", "--no-checkout", repoUrl, repoPath]);
     if (cloneResult.exitCode !== 0) {
       throw new Error(`Failed to clone ${repoUrl}: ${cloneResult.stderr}`);
     }
     const allShas = [diff.beforeRev, ...commits.map((c) => c.sha)];
-    const outputs = [];
-    for (const sha of allShas) {
+    const cmdParts = ["sh", "-c", buildCommand];
+    const buildFn = (sha) => {
       const checkoutResult = spawnCmd(["git", "checkout", sha], { cwd: repoPath });
       if (checkoutResult.exitCode !== 0) {
         throw new Error(`git checkout ${sha} failed: ${checkoutResult.stderr}`);
       }
-      const output = buildAtPath(repoPath, buildCommand, inputName);
-      outputs.push(output);
-    }
+      const result = spawnCmd(cmdParts, {
+        cwd: process.cwd(),
+        env: { ...process.env, CFLC_INPUT_PATH: repoPath, CFLC_INPUT_REV: sha }
+      });
+      if (result.exitCode !== 0) {
+        throw new Error(`Build command failed at ${sha}: ${result.stderr}`);
+      }
+      return result.stdout.trim();
+    };
+    const outFirst = buildFn(allShas[0]);
+    const outLast = buildFn(allShas[allShas.length - 1]);
+    const outputs = new Map;
+    outputs.set(0, outFirst);
+    outputs.set(allShas.length - 1, outLast);
+    bisect(0, allShas.length - 1, outFirst, outLast, allShas, outputs, buildFn);
     const relevant = [];
     const irrelevant = [];
     for (let i = 0;i < commits.length; i++) {
-      if (outputs[i + 1] !== outputs[i]) {
+      if (outputs.get(i + 1) !== outputs.get(i)) {
         relevant.push(commits[i]);
       } else {
         irrelevant.push(commits[i]);
@@ -66727,7 +66724,7 @@ async function filterCommitsByBuildRelevance(commits, diff, buildCommand, inputN
     }
     return { relevant, irrelevant };
   } finally {
-    fs2.rmSync(tmpDir, { recursive: true, force: true });
+    fs8.rmSync(tmpDir, { recursive: true, force: true });
   }
 }
 
@@ -66776,7 +66773,6 @@ async function run() {
   }
   const COMMIT_TRUNCATION_OVERHEAD = 350;
   const buildFilter = getInput("build-filter");
-  const buildFilterInput = getInput("build-filter-input");
   const result = ["# Flake inputs changelog"];
   info(`Fetching changed files for PR #${prNumber}`);
   const files = await getPullRequestChangedFiles(prNumber);
@@ -66814,18 +66810,19 @@ async function run() {
       result.push(`[\`${diff.beforeRev}\` -> \`${diff.rev}\`](https://github.com/${diff.owner}/${diff.repo}/compare/${diff.beforeRev}..${diff.rev})`);
       const commits = await compareCommits(diff.owner, diff.repo, diff.beforeRev, diff.rev);
       if (commits.length === 0) {
+        result.push("");
         result.push("> [!NOTE]");
         result.push("> Could not generate a detailed changelog — the commits have no common ancestor. " + "The repository history may have been rewritten.");
       }
       let bodySize = result.join(`
 `).length;
       let omitted = 0;
-      if (buildFilter && buildFilterInput && commits.length > 0) {
+      if (buildFilter && commits.length > 0) {
         info(`Running build-filter for ${diff.owner}/${diff.repo}`);
         let relevant = commits;
         let irrelevant = [];
         try {
-          const filtered = await filterCommitsByBuildRelevance(commits, diff, buildFilter, buildFilterInput);
+          const filtered = filterCommitsByBuildRelevance(commits, diff, buildFilter);
           relevant = filtered.relevant;
           irrelevant = filtered.irrelevant;
         } catch (e) {

--- a/src/api.test.ts
+++ b/src/api.test.ts
@@ -291,33 +291,6 @@ describe("upsertComment", () => {
         expect(body).toBe(`new body\n${COMMENT_TAG}`);
         expect(createCommentMock).not.toHaveBeenCalled();
     });
-
-    test("truncates body and emits warning when over 65,536 characters", async () => {
-        const body = "x".repeat(70_000);
-
-        await upsertComment(1, body);
-
-        const { body: posted } = (createCommentMock.mock.calls[0] as [{ body: string }])[0];
-        expect(posted.length).toBeLessThanOrEqual(65536);
-        expect(posted.endsWith(`\n${COMMENT_TAG}`)).toBe(true);
-        expect(posted).toContain("[!NOTE]");
-        expect(posted).toContain("truncated");
-        expect(logMock).toHaveBeenCalledWith(
-            "Comment body exceeded GitHub's maximum comment size of 65,536 characters and was truncated.",
-        );
-    });
-
-    test("does not truncate or warn when body fits within the limit", async () => {
-        const tag = `\n${COMMENT_TAG}`;
-        const body = "x".repeat(65536 - tag.length);
-
-        await upsertComment(1, body);
-
-        const { body: posted } = (createCommentMock.mock.calls[0] as [{ body: string }])[0];
-        expect(posted.length).toBe(65536);
-        expect(posted).not.toContain("[!NOTE]");
-        expect(logMock).not.toHaveBeenCalled();
-    });
 });
 
 describe("getPullRequestDetails", () => {

--- a/src/api.ts
+++ b/src/api.ts
@@ -118,38 +118,12 @@ const COMMENT_TAG_PATTERN = `<!-- mdarocha/comment-flake-lock-changelog -->`;
 
 // GitHub enforces a hard 65,536-character limit on issue/PR comment bodies.
 export const GITHUB_COMMENT_MAX_LENGTH = 65536;
-const TRUNCATION_NOTICE =
-    "\n\n> [!NOTE]\n> The changelog was truncated because it exceeded GitHub's maximum comment size of 65,536 characters.";
-
-/**
- * Attaches the identity tag to `body` and truncates the result to GitHub's
- * comment-size limit.  When truncation is needed the body is cut at the last
- * complete line that fits, and `TRUNCATION_NOTICE` is appended so readers know
- * the output is incomplete.
- */
-function buildCommentBody(body: string): string {
-    const tag = `\n${COMMENT_TAG_PATTERN}`;
-    const full = `${body}${tag}`;
-    if (full.length <= GITHUB_COMMENT_MAX_LENGTH) {
-        return full;
-    }
-    // Reserve space for the tag and the truncation notice, then cut at the
-    // last newline within the available window to avoid breaking markdown.
-    const available = GITHUB_COMMENT_MAX_LENGTH - tag.length - TRUNCATION_NOTICE.length;
-    const cutIndex = body.lastIndexOf("\n", available);
-    const safeBody = cutIndex > 0 ? body.slice(0, cutIndex) : body.slice(0, available);
-    return `${safeBody}${TRUNCATION_NOTICE}${tag}`;
-}
 
 export async function upsertComment(prNumber: number, body: string): Promise<void> {
     const client = getGithubClient();
     const { repo } = github.context;
 
-    const wouldExceed = `${body}\n${COMMENT_TAG_PATTERN}`.length > GITHUB_COMMENT_MAX_LENGTH;
-    if (wouldExceed) {
-        core.warning("Comment body exceeded GitHub's maximum comment size of 65,536 characters and was truncated.");
-    }
-    const taggedBody = buildCommentBody(body);
+    const taggedBody = `${body}\n${COMMENT_TAG_PATTERN}`;
 
     function hasCommentTag(comment: { body?: string | null }): boolean {
         return (

--- a/src/build-filter.test.ts
+++ b/src/build-filter.test.ts
@@ -1,0 +1,81 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { mockModule } from "~/utils/mockModule";
+
+type SpawnCall = { cmd: string; args: string[]; env: NodeJS.ProcessEnv | undefined };
+
+let spawnCalls: SpawnCall[] = [];
+let moduleMock: Awaited<ReturnType<typeof mockModule>>;
+// Maps a checked-out sha to the fingerprint the fake build command should "print" to stdout.
+let outputsBySha: Record<string, string> = {};
+
+beforeEach(async () => {
+    spawnCalls = [];
+    outputsBySha = {};
+
+    moduleMock = await mockModule("node:child_process", () => ({
+        spawnSync: mock((cmd: string, args: string[] = [], opts?: { cwd?: string; env?: NodeJS.ProcessEnv }) => {
+            spawnCalls.push({ cmd, args, env: opts?.env });
+
+            if (cmd === "which") {
+                return { status: 0, stdout: "/usr/bin/git", stderr: "" };
+            }
+            if (cmd === "git" && args[0] === "clone") {
+                return { status: 0, stdout: "", stderr: "" };
+            }
+            if (cmd === "git" && args[0] === "checkout") {
+                return { status: 0, stdout: "", stderr: "" };
+            }
+            if (cmd === "sh") {
+                const sha = opts?.env?.["CFLC_INPUT_REV"] ?? "";
+                return { status: 0, stdout: outputsBySha[sha] ?? "", stderr: "" };
+            }
+            return { status: 1, stdout: "", stderr: "unexpected command" };
+        }),
+    }));
+});
+
+afterEach(() => {
+    moduleMock.dispose();
+});
+
+describe("filterCommitsByBuildRelevance", () => {
+    test("passes CFLC_INPUT_NAME so one build command can target the input being bisected", async () => {
+        const { filterCommitsByBuildRelevance } = await import("~/buildFilter");
+
+        outputsBySha = { before: "out-a", c1: "out-a", c2: "out-a" };
+
+        filterCommitsByBuildRelevance(
+            [
+                { sha: "c1", message: "commit 1", url: "https://example.com/c1" },
+                { sha: "c2", message: "commit 2", url: "https://example.com/c2" },
+            ],
+            { owner: "acme", repo: "flake-utils", beforeRev: "before", rev: "c2", name: "flake-utils" },
+            'echo "$CFLC_INPUT_NAME"',
+        );
+
+        const buildCalls = spawnCalls.filter((c) => c.cmd === "sh");
+        expect(buildCalls.length).toBeGreaterThan(0);
+        for (const call of buildCalls) {
+            expect(call.env?.["CFLC_INPUT_NAME"]).toBe("flake-utils");
+        }
+    });
+
+    test("classifies commits as relevant only when they change the build fingerprint", async () => {
+        const { filterCommitsByBuildRelevance } = await import("~/buildFilter");
+
+        // before -> c1: output changes (relevant). c1 -> c2: output stays the same (irrelevant).
+        outputsBySha = { before: "out-a", c1: "out-b", c2: "out-b" };
+
+        const { relevant, irrelevant } = filterCommitsByBuildRelevance(
+            [
+                { sha: "c1", message: "commit 1", url: "https://example.com/c1" },
+                { sha: "c2", message: "commit 2", url: "https://example.com/c2" },
+            ],
+            { owner: "NixOS", repo: "nixpkgs", beforeRev: "before", rev: "c2", name: "nixpkgs" },
+            'echo "$CFLC_INPUT_REV"',
+        );
+
+        expect(relevant.map((c) => c.sha)).toEqual(["c1"]);
+        expect(irrelevant.map((c) => c.sha)).toEqual(["c2"]);
+    });
+});

--- a/src/buildFilter.ts
+++ b/src/buildFilter.ts
@@ -10,6 +10,7 @@ interface Diff {
     repo: string;
     beforeRev: string;
     rev: string;
+    name: string;
 }
 
 function spawnCmd(
@@ -68,8 +69,11 @@ function bisect(
  *
  * The upstream repo is cloned and checked out at various commits. For each build,
  * the user-provided build command is run as-is in process.cwd() (the Actions workspace)
- * with CFLC_INPUT_PATH set to the upstream checkout and CFLC_INPUT_REV set to the SHA.
- * The command's stdout is used as the build fingerprint.
+ * with CFLC_INPUT_NAME set to the flake input's name, CFLC_INPUT_PATH set to the
+ * upstream checkout, and CFLC_INPUT_REV set to the SHA. CFLC_INPUT_NAME lets a single
+ * build command handle whichever input is currently being bisected (e.g.
+ * `--override-input "$CFLC_INPUT_NAME" "path:$CFLC_INPUT_PATH"`), instead of hardcoding
+ * one input name. The command's stdout is used as the build fingerprint.
  *
  * Uses a bisect algorithm to minimize the number of builds: O(k log N) where
  * k = number of output change points, instead of O(N) for a linear scan.
@@ -108,7 +112,12 @@ export function filterCommitsByBuildRelevance(
             }
             const result = spawnCmd(cmdParts, {
                 cwd: process.cwd(),
-                env: { ...process.env, CFLC_INPUT_PATH: repoPath, CFLC_INPUT_REV: sha },
+                env: {
+                    ...process.env,
+                    CFLC_INPUT_NAME: diff.name,
+                    CFLC_INPUT_PATH: repoPath,
+                    CFLC_INPUT_REV: sha,
+                },
             });
             if (result.exitCode !== 0) {
                 throw new Error(`Build command failed at ${sha}: ${result.stderr}`);

--- a/src/buildFilter.ts
+++ b/src/buildFilter.ts
@@ -1,0 +1,108 @@
+import * as fs from "fs";
+import { spawnSync } from "node:child_process";
+import * as os from "os";
+import * as path from "path";
+
+type Commit = { sha: string; message: string; url: string };
+
+interface Diff {
+    owner: string;
+    repo: string;
+    beforeRev: string;
+    rev: string;
+}
+
+function spawnCmd(cmd: string[], opts?: { cwd?: string }): { stdout: string; stderr: string; exitCode: number } {
+    const result = spawnSync(cmd[0], cmd.slice(1), {
+        ...(opts?.cwd !== undefined ? { cwd: opts.cwd } : {}),
+        encoding: "utf8",
+    });
+    return {
+        stdout: result.stdout ?? "",
+        stderr: result.stderr ?? "",
+        exitCode: result.status ?? 1,
+    };
+}
+
+function checkToolAvailable(tool: string): boolean {
+    const result = spawnCmd(["which", tool]);
+    return result.exitCode === 0;
+}
+
+function buildAtPath(repoPath: string, buildCommand: string, inputName: string): string {
+    const fullCommand = `${buildCommand} --override-input ${inputName} path:${repoPath} --no-link --print-out-paths`;
+    const result = spawnCmd(["sh", "-c", fullCommand]);
+    if (result.exitCode !== 0) {
+        throw new Error(`Build failed: ${result.stderr}`);
+    }
+    return result.stdout.trim();
+}
+
+/**
+ * Filter commits by whether they affect the build output of the flake under test.
+ *
+ * For each commit in the changelog, the upstream repo is checked out at that commit
+ * and the build command is run with `--override-input <inputName> path:<checkout>`.
+ * A commit is "relevant" if its build output differs from the previous commit's output.
+ *
+ * Requires `git` and `nix` in PATH; throws a descriptive error if either is missing.
+ *
+ * NOTE: This performs one nix build per commit. For large changelogs this can be slow,
+ * but subsequent builds benefit from nix store deduplication/caching.
+ */
+export async function filterCommitsByBuildRelevance(
+    commits: Commit[],
+    diff: Diff,
+    buildCommand: string,
+    inputName: string,
+): Promise<{ relevant: Commit[]; irrelevant: Commit[] }> {
+    if (!checkToolAvailable("git")) {
+        throw new Error("git not found in PATH — cannot run build-filter");
+    }
+    if (!checkToolAvailable("nix")) {
+        throw new Error("nix not found in PATH — cannot run build-filter");
+    }
+
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "cflc-"));
+    try {
+        const repoPath = path.join(tmpDir, "repo");
+        const repoUrl = `https://github.com/${diff.owner}/${diff.repo}`;
+
+        // Blobless clone: fetch tree metadata only; blobs are fetched on demand during checkout.
+        const cloneResult = spawnCmd(["git", "clone", "--filter=blob:none", "--no-checkout", repoUrl, repoPath]);
+        if (cloneResult.exitCode !== 0) {
+            throw new Error(`Failed to clone ${repoUrl}: ${cloneResult.stderr}`);
+        }
+
+        // Build at beforeRev, then at each commit in order.
+        // outputs[0]   = beforeRev
+        // outputs[i+1] = commits[i]
+        const allShas = [diff.beforeRev, ...commits.map((c) => c.sha)];
+        const outputs: string[] = [];
+
+        for (const sha of allShas) {
+            const checkoutResult = spawnCmd(["git", "checkout", sha], { cwd: repoPath });
+            if (checkoutResult.exitCode !== 0) {
+                throw new Error(`git checkout ${sha} failed: ${checkoutResult.stderr}`);
+            }
+            const output = buildAtPath(repoPath, buildCommand, inputName);
+            outputs.push(output);
+        }
+
+        const relevant: Commit[] = [];
+        const irrelevant: Commit[] = [];
+
+        for (let i = 0; i < commits.length; i++) {
+            // outputs has length commits.length + 1, so i and i+1 are always valid indices.
+            if (outputs[i + 1] !== outputs[i]) {
+                relevant.push(commits[i] as Commit);
+            } else {
+                irrelevant.push(commits[i] as Commit);
+            }
+        }
+
+        return { relevant, irrelevant };
+    } finally {
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+}

--- a/src/buildFilter.ts
+++ b/src/buildFilter.ts
@@ -12,9 +12,13 @@ interface Diff {
     rev: string;
 }
 
-function spawnCmd(cmd: string[], opts?: { cwd?: string }): { stdout: string; stderr: string; exitCode: number } {
+function spawnCmd(
+    cmd: string[],
+    opts?: { cwd?: string; env?: NodeJS.ProcessEnv },
+): { stdout: string; stderr: string; exitCode: number } {
     const result = spawnSync(cmd[0], cmd.slice(1), {
         ...(opts?.cwd !== undefined ? { cwd: opts.cwd } : {}),
+        ...(opts?.env !== undefined ? { env: opts.env } : {}),
         encoding: "utf8",
     });
     return {
@@ -29,38 +33,56 @@ function checkToolAvailable(tool: string): boolean {
     return result.exitCode === 0;
 }
 
-function buildAtPath(repoPath: string, buildCommand: string, inputName: string): string {
-    const fullCommand = `${buildCommand} --override-input ${inputName} path:${repoPath} --no-link --print-out-paths`;
-    const result = spawnCmd(["sh", "-c", fullCommand]);
-    if (result.exitCode !== 0) {
-        throw new Error(`Build failed: ${result.stderr}`);
+/**
+ * Bisect the commit range to find all boundary points where the build output changes.
+ * O(k log N) builds where k = number of change points.
+ */
+function bisect(
+    lo: number,
+    hi: number,
+    outLo: string,
+    outHi: string,
+    allShas: string[],
+    outputs: Map<number, string>,
+    buildFn: (sha: string) => string,
+): void {
+    if (outLo === outHi) {
+        // Same output across range: all commits are irrelevant, fill without building
+        for (let i = lo + 1; i <= hi; i++) outputs.set(i, outLo);
+        return;
     }
-    return result.stdout.trim();
+    if (hi - lo === 1) {
+        // Adjacent commits with different outputs: boundary already known
+        outputs.set(hi, outHi);
+        return;
+    }
+    const mid = Math.floor((lo + hi) / 2);
+    const outMid = buildFn(allShas[mid]);
+    outputs.set(mid, outMid);
+    bisect(lo, mid, outLo, outMid, allShas, outputs, buildFn);
+    bisect(mid, hi, outMid, outHi, allShas, outputs, buildFn);
 }
 
 /**
- * Filter commits by whether they affect the build output of the flake under test.
+ * Filter commits by whether they affect the build output.
  *
- * For each commit in the changelog, the upstream repo is checked out at that commit
- * and the build command is run with `--override-input <inputName> path:<checkout>`.
- * A commit is "relevant" if its build output differs from the previous commit's output.
+ * The upstream repo is cloned and checked out at various commits. For each build,
+ * the user-provided build command is run as-is in process.cwd() (the Actions workspace)
+ * with CFLC_INPUT_PATH set to the upstream checkout and CFLC_INPUT_REV set to the SHA.
+ * The command's stdout is used as the build fingerprint.
  *
- * Requires `git` and `nix` in PATH; throws a descriptive error if either is missing.
+ * Uses a bisect algorithm to minimize the number of builds: O(k log N) where
+ * k = number of output change points, instead of O(N) for a linear scan.
  *
- * NOTE: This performs one nix build per commit. For large changelogs this can be slow,
- * but subsequent builds benefit from nix store deduplication/caching.
+ * Requires `git` in PATH; throws a descriptive error if missing.
  */
-export async function filterCommitsByBuildRelevance(
+export function filterCommitsByBuildRelevance(
     commits: Commit[],
     diff: Diff,
     buildCommand: string,
-    inputName: string,
-): Promise<{ relevant: Commit[]; irrelevant: Commit[] }> {
+): { relevant: Commit[]; irrelevant: Commit[] } {
     if (!checkToolAvailable("git")) {
-        throw new Error("git not found in PATH — cannot run build-filter");
-    }
-    if (!checkToolAvailable("nix")) {
-        throw new Error("nix not found in PATH — cannot run build-filter");
+        throw new Error("git not found in PATH \u2014 cannot run build-filter");
     }
 
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "cflc-"));
@@ -74,30 +96,46 @@ export async function filterCommitsByBuildRelevance(
             throw new Error(`Failed to clone ${repoUrl}: ${cloneResult.stderr}`);
         }
 
-        // Build at beforeRev, then at each commit in order.
-        // outputs[0]   = beforeRev
-        // outputs[i+1] = commits[i]
+        // allShas[0] = beforeRev, allShas[1..N] = commits[0..N-1].sha
         const allShas = [diff.beforeRev, ...commits.map((c) => c.sha)];
-        const outputs: string[] = [];
 
-        for (const sha of allShas) {
+        const cmdParts = ["sh", "-c", buildCommand];
+
+        const buildFn = (sha: string): string => {
             const checkoutResult = spawnCmd(["git", "checkout", sha], { cwd: repoPath });
             if (checkoutResult.exitCode !== 0) {
                 throw new Error(`git checkout ${sha} failed: ${checkoutResult.stderr}`);
             }
-            const output = buildAtPath(repoPath, buildCommand, inputName);
-            outputs.push(output);
-        }
+            const result = spawnCmd(cmdParts, {
+                cwd: process.cwd(),
+                env: { ...process.env, CFLC_INPUT_PATH: repoPath, CFLC_INPUT_REV: sha },
+            });
+            if (result.exitCode !== 0) {
+                throw new Error(`Build command failed at ${sha}: ${result.stderr}`);
+            }
+            return result.stdout.trim();
+        };
 
+        // Build at endpoints
+        const outFirst = buildFn(allShas[0]);
+        const outLast = buildFn(allShas[allShas.length - 1]);
+
+        const outputs = new Map<number, string>();
+        outputs.set(0, outFirst);
+        outputs.set(allShas.length - 1, outLast);
+
+        // Bisect to find all change boundaries
+        bisect(0, allShas.length - 1, outFirst, outLast, allShas, outputs, buildFn);
+
+        // Classify commits: commit[i] is relevant if outputs[i+1] !== outputs[i]
         const relevant: Commit[] = [];
         const irrelevant: Commit[] = [];
 
         for (let i = 0; i < commits.length; i++) {
-            // outputs has length commits.length + 1, so i and i+1 are always valid indices.
-            if (outputs[i + 1] !== outputs[i]) {
-                relevant.push(commits[i] as Commit);
+            if (outputs.get(i + 1) !== outputs.get(i)) {
+                relevant.push(commits[i]);
             } else {
-                irrelevant.push(commits[i] as Commit);
+                irrelevant.push(commits[i]);
             }
         }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -101,7 +101,6 @@ export async function run(): Promise<void> {
     const COMMIT_TRUNCATION_OVERHEAD = 350;
 
     const buildFilter = core.getInput("build-filter");
-    const buildFilterInput = core.getInput("build-filter-input");
 
     const result = ["# Flake inputs changelog"];
     core.info(`Fetching changed files for PR #${prNumber}`);
@@ -163,6 +162,7 @@ export async function run(): Promise<void> {
             const commits = await compareCommits(diff.owner, diff.repo, diff.beforeRev, diff.rev);
 
             if (commits.length === 0) {
+                result.push("");
                 result.push("> [!NOTE]");
                 result.push(
                     "> Could not generate a detailed changelog — the commits have no common ancestor. " +
@@ -175,14 +175,14 @@ export async function run(): Promise<void> {
             let bodySize = result.join("\n").length;
             let omitted = 0;
 
-            if (buildFilter && buildFilterInput && commits.length > 0) {
+            if (buildFilter && commits.length > 0) {
                 core.info(`Running build-filter for ${diff.owner}/${diff.repo}`);
 
                 let relevant = commits;
                 let irrelevant: typeof commits = [];
 
                 try {
-                    const filtered = await filterCommitsByBuildRelevance(commits, diff, buildFilter, buildFilterInput);
+                    const filtered = filterCommitsByBuildRelevance(commits, diff, buildFilter);
                     relevant = filtered.relevant;
                     irrelevant = filtered.irrelevant;
                 } catch (e) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -54,13 +54,17 @@ function parseLockfile(content: string): Lockfile {
         );
 }
 
-function getLockfileDiffs(before: Lockfile, after: Lockfile): Array<LockfileItem & { beforeRev: string }> {
+function getLockfileDiffs(
+    before: Lockfile,
+    after: Lockfile,
+): Array<LockfileItem & { beforeRev: string; name: string }> {
     return Object.entries(after)
         .filter(([_key, value]) => value.type === "github")
         .filter(([key, value]) => before[key] && before[key].rev && before[key].rev !== value.rev)
         .map(([key, value]) => ({
             ...value,
             beforeRev: before[key].rev,
+            name: key,
         }));
 }
 
@@ -116,7 +120,7 @@ export async function run(): Promise<void> {
     const prDetails = await getPullRequestDetails(prNumber);
 
     // Pass 1: compute all diffs across all lockfiles (no compareCommits calls yet)
-    type LockfileDiff = LockfileItem & { beforeRev: string };
+    type LockfileDiff = LockfileItem & { beforeRev: string; name: string };
     const allDiffsByLockfile: Array<{ lockfile: string; diffs: LockfileDiff[] }> = [];
 
     for (const lockfile of lockfiles) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -11,6 +11,7 @@ import {
     saveCacheForRepo,
     upsertComment,
 } from "~/api";
+import { filterCommitsByBuildRelevance } from "~/buildFilter";
 
 interface LockfileItem {
     type: string;
@@ -63,6 +64,32 @@ function getLockfileDiffs(before: Lockfile, after: Lockfile): Array<LockfileItem
         }));
 }
 
+async function renderCommitListItem(
+    result: string[],
+    owner: string,
+    repo: string,
+    commit: { sha: string; message: string; url: string },
+): Promise<void> {
+    core.info(`Checking for PRs associated with commit ${commit.sha}`);
+
+    // if the commit message contains a @mention, we add an unicode word joiner
+    // between @ and username, to avoid spamming the mentioned user.
+    const commitMessage = commit.message.replace(/@/g, "@\u200D");
+    const commitUrl = commit.url.replace("https://github.com", "https://redirect.github.com");
+    const commitListItem = `- [${commitMessage}](${commitUrl})`;
+
+    const pr = await getPullRequestForCommit(owner, repo, commit.sha);
+    if (pr) {
+        // use redirect.github.com instead of github.com to avoid spamming backlinks
+        const prUrl = pr.url.replace("https://github.com", "https://redirect.github.com");
+        result.push(
+            `${commitListItem} - [![PR Icon](https://icongr.am/octicons/git-pull-request.svg?size=14&color=abb4bf) PR #${pr.id}](${prUrl})`,
+        );
+    } else {
+        result.push(commitListItem);
+    }
+}
+
 export async function run(): Promise<void> {
     const prNumber = Number(core.getInput("pull-request-number"));
     if (isNaN(prNumber) || prNumber === 0) {
@@ -72,6 +99,9 @@ export async function run(): Promise<void> {
     // Space reserved for the identity tag appended by upsertComment and a truncation notice.
     // This covers: tag (~48 chars) + "> [!NOTE]\n> N more commit(s) ..." (~250 chars) + small buffer.
     const COMMIT_TRUNCATION_OVERHEAD = 350;
+
+    const buildFilter = core.getInput("build-filter");
+    const buildFilterInput = core.getInput("build-filter-input");
 
     const result = ["# Flake inputs changelog"];
     core.info(`Fetching changed files for PR #${prNumber}`);
@@ -145,37 +175,69 @@ export async function run(): Promise<void> {
             let bodySize = result.join("\n").length;
             let omitted = 0;
 
-            for (let i = 0; i < commits.length; i++) {
-                const commit = commits[i];
+            if (buildFilter && buildFilterInput && commits.length > 0) {
+                core.info(`Running build-filter for ${diff.owner}/${diff.repo}`);
 
-                // if the commit message contains a @mention, we add an unicode word joiner
-                // between @ and username, to avoid spamming the mentioned user.
-                const commitMessage = commit.message.replace(/@/g, "@\u200D");
-                const commitUrl = commit.url.replace("https://github.com", "https://redirect.github.com");
+                let relevant = commits;
+                let irrelevant: typeof commits = [];
 
-                const commitListItem = `- [${commitMessage}](${commitUrl})`;
-
-                core.info(`Checking for PRs associated with commit ${commit.sha}`);
-                const pr = await getPullRequestForCommit(diff.owner, diff.repo, commit.sha);
-                let line: string;
-                if (pr) {
-                    // use redirect.github.com instead of github.com to avoid spamming backlinks
-                    const prUrl = pr.url.replace("https://github.com", "https://redirect.github.com");
-                    line = `${commitListItem} - [![PR Icon](https://icongr.am/octicons/git-pull-request.svg?size=14&color=abb4bf) PR #${pr.id}](${prUrl})`;
-                } else {
-                    line = commitListItem;
+                try {
+                    const filtered = await filterCommitsByBuildRelevance(commits, diff, buildFilter, buildFilterInput);
+                    relevant = filtered.relevant;
+                    irrelevant = filtered.irrelevant;
+                } catch (e) {
+                    core.warning(`build-filter failed: ${e}. Showing all commits.`);
                 }
 
-                // Check if adding this commit would exceed the limit.
-                if (bodySize + line.length + 1 + COMMIT_TRUNCATION_OVERHEAD > GITHUB_COMMENT_MAX_LENGTH) {
-                    omitted = commits.length - i;
-                    break;
+                if (relevant.length === 0) {
+                    result.push("");
+                    result.push("> [!NOTE]");
+                    result.push("> All commits in this range produced identical build output.");
                 }
 
-                result.push(line);
-                bodySize += line.length + 1;
+                for (const commit of relevant) {
+                    await renderCommitListItem(result, diff.owner, diff.repo, commit);
+                }
+
+                if (irrelevant.length > 0) {
+                    result.push("");
+                    result.push(
+                        `<details><summary>${irrelevant.length} commit${irrelevant.length === 1 ? "" : "s"} that did not affect the build output</summary>`,
+                    );
+                    result.push("");
+                    for (const commit of irrelevant) {
+                        await renderCommitListItem(result, diff.owner, diff.repo, commit);
+                    }
+                    result.push("");
+                    result.push("</details>");
+                }
+            } else {
+                for (let i = 0; i < commits.length; i++) {
+                    const commit = commits[i];
+
+                    const commitMessage = commit.message.replace(/@/g, "@\u200D");
+                    const commitUrl = commit.url.replace("https://github.com", "https://redirect.github.com");
+                    const commitListItem = `- [${commitMessage}](${commitUrl})`;
+
+                    core.info(`Checking for PRs associated with commit ${commit.sha}`);
+                    const pr = await getPullRequestForCommit(diff.owner, diff.repo, commit.sha);
+                    let line: string;
+                    if (pr) {
+                        const prUrl = pr.url.replace("https://github.com", "https://redirect.github.com");
+                        line = `${commitListItem} - [![PR Icon](https://icongr.am/octicons/git-pull-request.svg?size=14&color=abb4bf) PR #${pr.id}](${prUrl})`;
+                    } else {
+                        line = commitListItem;
+                    }
+
+                    if (bodySize + line.length + 1 + COMMIT_TRUNCATION_OVERHEAD > GITHUB_COMMENT_MAX_LENGTH) {
+                        omitted = commits.length - i;
+                        break;
+                    }
+
+                    result.push(line);
+                    bodySize += line.length + 1;
+                }
             }
-
             if (omitted > 0) {
                 result.push("");
                 result.push("> [!NOTE]");


### PR DESCRIPTION
Closes #208

Adds an optional `build-filter` input. When set, the action builds your flake at a handful of upstream commits per changed input and hides commits that didn't change the build output behind a collapsed section, so noisy bumps (mainly `nixpkgs`) produce a shorter, more relevant changelog.

See the [Build filter](https://github.com/mdarocha/comment-flake-lock-changelog/blob/feat/208-build-filter/README.md#build-filter) section of the README for usage, the available environment variables (including `CFLC_INPUT_NAME`, so one command supports every input in the lockfile, not just `nixpkgs`), what the command's output should look like, and a tip on using a cheap Nix change sentinel instead of a full build.

### Example usage

```yaml
- uses: mdarocha/comment-flake-lock-changelog@main
  with:
    pull-request-number: ${{ github.event.pull_request.number }}
    build-filter: 'nix build --override-input "$CFLC_INPUT_NAME" "path:$CFLC_INPUT_PATH" --print-out-paths'
```

### Graceful degradation

If `git` is not in PATH, or the build command fails, the action logs a warning and falls back to showing all commits.
