### PR TITLE
Support build-filter for every changed input, not just nixpkgs

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ This action is meant to be used as a helper to [update-flake-lock](https://githu
 | :-- | :-- | :-- |
 | `pull-request-number` | Id of the PR that will be analyzed by the action | none, **required** |
 | `token` | Token used for authentication with Github API | `${{ github.token }}` |
+| `build-filter` | Shell command to run at each upstream commit to determine build relevance. See [Build filter](#build-filter) below. | none |
 
 ## Example usage
 
@@ -48,3 +49,86 @@ jobs:
 ## Example result
 
 ![image](https://github.com/user-attachments/assets/f6a2217f-3d44-462b-a9c9-a1393206369e)
+
+## Build filter
+
+By default, every upstream commit between the old and new `rev` of a flake input is listed in the
+changelog. For inputs like `nixpkgs`, most commits don't actually change anything that the flake
+depends on (docs, unrelated packages, CI, etc.), which makes the changelog noisy. Setting
+`build-filter` runs a build at a subset of the upstream commits and hides commits that didn't
+change the build output behind a collapsed "did not affect the build output" section.
+
+### How it works
+
+For **each** flake input that changed in the lockfile (not just `nixpkgs`), the action:
+
+1. Clones the input's upstream repository with `--filter=blob:none` (a blobless clone — cheap on
+   bandwidth since blobs are fetched lazily on checkout).
+2. Runs your `build-filter` command at the **first and last** commit of the range only.
+   - If the two outputs are identical, every commit in between is marked irrelevant — 2 builds
+     total, no further work needed.
+3. If the outputs differ, the action **bisects** the range: it builds the midpoint commit, compares
+   its output to both ends, and recurses only into the sub-ranges whose endpoints disagree. Ranges
+   whose endpoints already agree are skipped entirely.
+
+This costs O(k log n) builds, where `n` is the number of commits in the range and `k` is the number
+of times the output actually changes — versus O(n) for a naive linear scan. Worst case (every
+commit changes the output) is still bounded at ~2n builds; best case (no commit matters) is 2
+builds regardless of range size.
+
+Because the algorithm only compares the *build output*, not the diff, it works even when the
+relationship between commit content and build output isn't obvious — e.g. it correctly ignores
+reverts, commits that touch the source but not any derivation actually used, or refactors that
+don't change what gets built.
+
+### What your `build-filter` command must output
+
+The command is run once per commit that the bisection needs to inspect. Its **stdout** is treated
+as an opaque fingerprint of the build for that commit — the action never inspects its meaning,
+only compares it for equality between commits. It should be:
+
+- **Deterministic** for a given commit — the same commit must always produce the same fingerprint,
+  otherwise the bisection will produce inconsistent (and possibly contradictory) results.
+- **Sensitive to build-relevant changes, and only those** — it should change whenever something a
+  consumer of the flake would care about changes (e.g. a package's contents or version), and stay
+  the same otherwise (e.g. ignore embedded timestamps or build-machine-specific paths).
+- A single line is enough; a Nix store path (e.g. the output of `nix build --print-out-paths`) or a
+  content hash both work well.
+
+A non-zero exit code from the command is treated as a failure of the whole build-filter step for
+that input: the action logs a warning and falls back to showing every commit for that input
+unfiltered, rather than guessing.
+
+### Environment variables
+
+The command runs as-is (no extra Nix flags are injected) in the Actions workspace — the same
+directory your workflow already checked out — with these variables set:
+
+| Variable | Description |
+| :-- | :-- |
+| `CFLC_INPUT_NAME` | The name of the flake input being tested, e.g. `nixpkgs`. Use this instead of hardcoding an input name so the same command works for **every** input that changed, not just one. |
+| `CFLC_INPUT_PATH` | Path to the upstream checkout, at the commit currently being tested. |
+| `CFLC_INPUT_REV` | The commit SHA currently checked out at `CFLC_INPUT_PATH`. |
+
+```yaml
+- uses: mdarocha/comment-flake-lock-changelog@main
+  with:
+    pull-request-number: ${{ github.event.pull_request.number }}
+    build-filter: 'nix build --override-input "$CFLC_INPUT_NAME" "path:$CFLC_INPUT_PATH" --print-out-paths'
+```
+
+Using `$CFLC_INPUT_NAME` lets one `build-filter` command handle every input in the lockfile. A
+command that hardcodes a single input name (e.g. always `--override-input nixpkgs ...`) will
+silently override the wrong input whenever a *different* input's history is being bisected, which
+gives meaningless or broken build results for that input.
+
+### A note on inputs that change together
+
+When a PR updates multiple inputs at once, each input's commit range is bisected independently, and
+the build for input A is always run against the **other** inputs pinned at their final (post-update)
+versions — not their pre-update versions. This mirrors what the flake will actually build with once
+the whole PR is merged, so it's the right comparison for "does this commit matter for my final flake
+output". It does mean that if two inputs' updates are entangled (e.g. a `nixpkgs` bump that only
+builds because a `flake-utils` bump also landed), bisecting `nixpkgs` alone won't observe an
+inconsistent intermediate state — the other input is never rolled back, so the fingerprint
+differences you see are attributable to the input actually being bisected.

--- a/action.yml
+++ b/action.yml
@@ -12,7 +12,7 @@ inputs:
     required: false
     default: ${{ github.token }}
   build-filter:
-    description: "When set, run this shell command at each upstream commit to determine build relevance. The command receives CFLC_INPUT_PATH (path to the upstream checkout) and CFLC_INPUT_REV (commit SHA) as environment variables. Its stdout is used as a build fingerprint — commits that change the output are marked relevant. Requires git in PATH."
+    description: "When set, run this shell command at each upstream commit to determine build relevance. The command receives CFLC_INPUT_NAME (the flake input's name, e.g. `nixpkgs`), CFLC_INPUT_PATH (path to the upstream checkout), and CFLC_INPUT_REV (commit SHA) as environment variables, so one command can support every input in the lockfile, not just a single hardcoded one. Its stdout is used as a build fingerprint — commits that change the output are marked relevant. Requires git in PATH."
     required: false
     default: ""
 runs:

--- a/dist/index.mjs
+++ b/dist/index.mjs
@@ -66700,7 +66700,12 @@ function filterCommitsByBuildRelevance(commits, diff, buildCommand) {
       }
       const result = spawnCmd(cmdParts, {
         cwd: process.cwd(),
-        env: { ...process.env, CFLC_INPUT_PATH: repoPath, CFLC_INPUT_REV: sha }
+        env: {
+          ...process.env,
+          CFLC_INPUT_NAME: diff.name,
+          CFLC_INPUT_PATH: repoPath,
+          CFLC_INPUT_REV: sha
+        }
       });
       if (result.exitCode !== 0) {
         throw new Error(`Build command failed at ${sha}: ${result.stderr}`);
@@ -66750,7 +66755,8 @@ function parseLockfile(content) {
 function getLockfileDiffs(before, after) {
   return Object.entries(after).filter(([_key, value]) => value.type === "github").filter(([key, value]) => before[key] && before[key].rev && before[key].rev !== value.rev).map(([key, value]) => ({
     ...value,
-    beforeRev: before[key].rev
+    beforeRev: before[key].rev,
+    name: key
   }));
 }
 async function renderCommitListItem(result, owner, repo, commit) {

--- a/src/build-filter.test.ts
+++ b/src/build-filter.test.ts
@@ -1,0 +1,81 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { mockModule } from "~/utils/mockModule";
+
+type SpawnCall = { cmd: string; args: string[]; env: NodeJS.ProcessEnv | undefined };
+
+let spawnCalls: SpawnCall[] = [];
+let moduleMock: Awaited<ReturnType<typeof mockModule>>;
+// Maps a checked-out sha to the fingerprint the fake build command should "print" to stdout.
+let outputsBySha: Record<string, string> = {};
+
+beforeEach(async () => {
+    spawnCalls = [];
+    outputsBySha = {};
+
+    moduleMock = await mockModule("node:child_process", () => ({
+        spawnSync: mock((cmd: string, args: string[] = [], opts?: { cwd?: string; env?: NodeJS.ProcessEnv }) => {
+            spawnCalls.push({ cmd, args, env: opts?.env });
+
+            if (cmd === "which") {
+                return { status: 0, stdout: "/usr/bin/git", stderr: "" };
+            }
+            if (cmd === "git" && args[0] === "clone") {
+                return { status: 0, stdout: "", stderr: "" };
+            }
+            if (cmd === "git" && args[0] === "checkout") {
+                return { status: 0, stdout: "", stderr: "" };
+            }
+            if (cmd === "sh") {
+                const sha = opts?.env?.["CFLC_INPUT_REV"] ?? "";
+                return { status: 0, stdout: outputsBySha[sha] ?? "", stderr: "" };
+            }
+            return { status: 1, stdout: "", stderr: "unexpected command" };
+        }),
+    }));
+});
+
+afterEach(() => {
+    moduleMock.dispose();
+});
+
+describe("filterCommitsByBuildRelevance", () => {
+    test("passes CFLC_INPUT_NAME so one build command can target the input being bisected", async () => {
+        const { filterCommitsByBuildRelevance } = await import("~/buildFilter");
+
+        outputsBySha = { before: "out-a", c1: "out-a", c2: "out-a" };
+
+        filterCommitsByBuildRelevance(
+            [
+                { sha: "c1", message: "commit 1", url: "https://example.com/c1" },
+                { sha: "c2", message: "commit 2", url: "https://example.com/c2" },
+            ],
+            { owner: "acme", repo: "flake-utils", beforeRev: "before", rev: "c2", name: "flake-utils" },
+            'echo "$CFLC_INPUT_NAME"',
+        );
+
+        const buildCalls = spawnCalls.filter((c) => c.cmd === "sh");
+        expect(buildCalls.length).toBeGreaterThan(0);
+        for (const call of buildCalls) {
+            expect(call.env?.["CFLC_INPUT_NAME"]).toBe("flake-utils");
+        }
+    });
+
+    test("classifies commits as relevant only when they change the build fingerprint", async () => {
+        const { filterCommitsByBuildRelevance } = await import("~/buildFilter");
+
+        // before -> c1: output changes (relevant). c1 -> c2: output stays the same (irrelevant).
+        outputsBySha = { before: "out-a", c1: "out-b", c2: "out-b" };
+
+        const { relevant, irrelevant } = filterCommitsByBuildRelevance(
+            [
+                { sha: "c1", message: "commit 1", url: "https://example.com/c1" },
+                { sha: "c2", message: "commit 2", url: "https://example.com/c2" },
+            ],
+            { owner: "NixOS", repo: "nixpkgs", beforeRev: "before", rev: "c2", name: "nixpkgs" },
+            'echo "$CFLC_INPUT_REV"',
+        );
+
+        expect(relevant.map((c) => c.sha)).toEqual(["c1"]);
+        expect(irrelevant.map((c) => c.sha)).toEqual(["c2"]);
+    });
+});

--- a/src/buildFilter.ts
+++ b/src/buildFilter.ts
@@ -10,6 +10,7 @@ interface Diff {
     repo: string;
     beforeRev: string;
     rev: string;
+    name: string;
 }
 
 function spawnCmd(
@@ -68,8 +69,11 @@ function bisect(
  *
  * The upstream repo is cloned and checked out at various commits. For each build,
  * the user-provided build command is run as-is in process.cwd() (the Actions workspace)
- * with CFLC_INPUT_PATH set to the upstream checkout and CFLC_INPUT_REV set to the SHA.
- * The command's stdout is used as the build fingerprint.
+ * with CFLC_INPUT_NAME set to the flake input's name, CFLC_INPUT_PATH set to the
+ * upstream checkout, and CFLC_INPUT_REV set to the SHA. CFLC_INPUT_NAME lets a single
+ * build command handle whichever input is currently being bisected (e.g.
+ * `--override-input "$CFLC_INPUT_NAME" "path:$CFLC_INPUT_PATH"`), instead of hardcoding
+ * one input name. The command's stdout is used as the build fingerprint.
  *
  * Uses a bisect algorithm to minimize the number of builds: O(k log N) where
  * k = number of output change points, instead of O(N) for a linear scan.
@@ -108,7 +112,12 @@ export function filterCommitsByBuildRelevance(
             }
             const result = spawnCmd(cmdParts, {
                 cwd: process.cwd(),
-                env: { ...process.env, CFLC_INPUT_PATH: repoPath, CFLC_INPUT_REV: sha },
+                env: {
+                    ...process.env,
+                    CFLC_INPUT_NAME: diff.name,
+                    CFLC_INPUT_PATH: repoPath,
+                    CFLC_INPUT_REV: sha,
+                },
             });
             if (result.exitCode !== 0) {
                 throw new Error(`Build command failed at ${sha}: ${result.stderr}`);

--- a/src/main.ts
+++ b/src/main.ts
@@ -54,13 +54,17 @@ function parseLockfile(content: string): Lockfile {
         );
 }
 
-function getLockfileDiffs(before: Lockfile, after: Lockfile): Array<LockfileItem & { beforeRev: string }> {
+function getLockfileDiffs(
+    before: Lockfile,
+    after: Lockfile,
+): Array<LockfileItem & { beforeRev: string; name: string }> {
     return Object.entries(after)
         .filter(([_key, value]) => value.type === "github")
         .filter(([key, value]) => before[key] && before[key].rev && before[key].rev !== value.rev)
         .map(([key, value]) => ({
             ...value,
             beforeRev: before[key].rev,
+            name: key,
         }));
 }
 
@@ -116,7 +120,7 @@ export async function run(): Promise<void> {
     const prDetails = await getPullRequestDetails(prNumber);
 
     // Pass 1: compute all diffs across all lockfiles (no compareCommits calls yet)
-    type LockfileDiff = LockfileItem & { beforeRev: string };
+    type LockfileDiff = LockfileItem & { beforeRev: string; name: string };
     const allDiffsByLockfile: Array<{ lockfile: string; diffs: LockfileDiff[] }> = [];
 
     for (const lockfile of lockfiles) {


### PR DESCRIPTION
Extends #299 (`build-filter`) per review feedback: document the feature and fix it to work for any changed input, not just the one hardcoded in the user's build command.

### Bug: `build-filter` only worked for one hardcoded input name

`filterCommitsByBuildRelevance` is called once per changed flake input, always with the *same* user-supplied `build-filter` command. The README's own example (`nix build --override-input nixpkgs path:$CFLC_INPUT_PATH`) hardcodes `nixpkgs`. When a PR bumps more than one input (e.g. `nixpkgs` *and* `flake-utils`), the identical command runs while bisecting `flake-utils`'s history too — silently overriding `nixpkgs` with the `flake-utils` checkout instead of testing what actually changed. Depending on the flake, this either builds something nonsensical or fails outright, and either way the relevance verdict for that input is meaningless.

**Fix:** thread the flake input's own name through as a new `CFLC_INPUT_NAME` env var (alongside the existing `CFLC_INPUT_PATH`/`CFLC_INPUT_REV`), so one `build-filter` command can target whichever input is currently being tested:

```yaml
build-filter: 'nix build --override-input "$CFLC_INPUT_NAME" "path:$CFLC_INPUT_PATH" --print-out-paths'
```

`getLockfileDiffs` previously discarded the flake input's key when building the diff list — added `name` to the diff/`LockfileDiff` type so it's available to pass through.

### Cross-input correlation

Investigated whether bisecting one input while other inputs sit at their already-updated (post-PR) versions could produce misleading results when multiple inputs change together. It doesn't: each input's bisection always builds against the *other* inputs pinned at their final lockfile state (never rolled back to their pre-PR versions), so the fingerprint differences observed are attributable to the input actually being bisected, and the comparison matches what the flake will build once the whole PR lands. Documented this explicitly in the README so it isn't a surprise for consumers with entangled input bumps.

### Docs

Added a "Build filter" section to the README covering:
- How the bisection algorithm works and its complexity (O(k log n) builds)
- What the `build-filter` command's stdout must be (a deterministic, build-sensitive fingerprint) and what a non-zero exit code does (falls back to showing all commits, unfiltered)
- The three env vars available to the command, with the multi-input caveat above
- The cross-input correlation note

### Testing

Added `src/build-filter.test.ts` covering that `CFLC_INPUT_NAME` is passed correctly per-diff, and basic relevant/irrelevant classification via the bisection.


---
_Generated by [Claude Code](https://claude.ai/code/session_016XMcbpzc3v7Mz5fG6uicuY)_