### PR TITLE
Declare action runtime as node24

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -16,5 +16,5 @@ inputs:
     required: false
     default: ""
 runs:
-  using: node20
+  using: node24
   main: dist/index.mjs


### PR DESCRIPTION
## Summary

GitHub Actions runners already force this action onto Node.js 24 with a deprecation warning, since Node 20 is [deprecated](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/):

```
##[warning]Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: mdarocha/comment-flake-lock-changelog@...
```

Observed while smoke-testing [nix-magic-setup#23](https://github.com/mdarocha/nix-magic-setup/pull/23) (which had this action's `main` branch temporarily pinned) against a real deploy in [mdarocha/pondinfra#141](https://github.com/mdarocha/pondinfra/pull/141).

## Changes

- `action.yml`: `using: node20` → `using: node24`.

No other change needed — the build targets a generic `node` runtime (`bun build --target=node`) and `tsconfig.json` targets `ESNext`, neither pinned to a specific Node version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016MYz49D9GAahQN6haYW3Nb)_