### PR TITLE
Fix changelog comment formatting

### DIFF
--- a/dist/index.mjs
+++ b/dist/index.mjs
@@ -66786,14 +66786,19 @@ async function run() {
   }
   const TAG_OVERHEAD = `
 ${COMMENT_TAG_PATTERN}`.length;
+  function shortSha(sha) {
+    return sha.slice(0, 7);
+  }
   function diffHeaderBlock(diff) {
     return [
       `### [${diff.owner}/${diff.repo}](https://github.com/${diff.owner}/${diff.repo})`,
       "",
-      "<details><summary>Changelog</summary>",
-      "",
-      `[\`${diff.beforeRev}\` -> \`${diff.rev}\`](https://github.com/${diff.owner}/${diff.repo}/compare/${diff.beforeRev}..${diff.rev})`
+      `[\`${shortSha(diff.beforeRev)}\` -> \`${shortSha(diff.rev)}\`](https://github.com/${diff.owner}/${diff.repo}/compare/${diff.beforeRev}..${diff.rev})`
     ].join(`
+`);
+  }
+  function changelogAccordionOpenBlock() {
+    return ["", "<details><summary>Changelog</summary>", ""].join(`
 `);
   }
   function noCommonAncestorBlock() {
@@ -66823,8 +66828,7 @@ ${COMMENT_TAG_PATTERN}`.length;
   function buildOmittedNote(owner, repo, beforeRev, rev, count) {
     return `
 
-> [!NOTE]
-` + `> ${count} more commit(s) were not shown (comment size limit). ` + `[View full comparison](https://github.com/${owner}/${repo}/compare/${beforeRev}..${rev})
+> ` + `${count} more commit(s) were not shown (comment size limit). ` + `[View full comparison](https://github.com/${owner}/${repo}/compare/${beforeRev}..${rev})
 `;
   }
   function commitListItem(commit) {
@@ -66897,6 +66901,7 @@ ${COMMENT_TAG_PATTERN}`.length;
       reserved += `## ${lockfile}`.length + 1;
     }
     reserved += diffHeaderBlock(diff).length + 1;
+    reserved += changelogAccordionOpenBlock().length + 1;
     reserved += closingBlock().length + 1;
     if (relevant.length === 0 && irrelevant.length === 0) {
       reserved += noCommonAncestorBlock().length + 1;
@@ -66924,11 +66929,16 @@ ${COMMENT_TAG_PATTERN}`.length;
     }
     result.push(diffHeaderBlock(diff));
     if (relevant.length === 0 && irrelevant.length === 0) {
+      result.push(changelogAccordionOpenBlock());
       result.push(closingBlock());
       result.push(noCommonAncestorBlock());
       await saveCacheForRepo(diff.owner, diff.repo);
       continue;
     }
+    if (relevant.length === 0) {
+      result.push(allIrrelevantNoteBlock());
+    }
+    result.push(changelogAccordionOpenBlock());
     let omittedRelevant = 0;
     if (relevant.length > 0) {
       result.push(firstLine);
@@ -66965,9 +66975,7 @@ ${COMMENT_TAG_PATTERN}`.length;
     }
     result.push(closingBlock());
     await saveCacheForRepo(diff.owner, diff.repo);
-    if (relevant.length === 0) {
-      result.push(allIrrelevantNoteBlock());
-    } else if (omittedRelevant > 0) {
+    if (omittedRelevant > 0) {
       result.push(buildOmittedNote(diff.owner, diff.repo, diff.beforeRev, diff.rev, omittedRelevant));
     }
   }

--- a/src/main.ts
+++ b/src/main.ts
@@ -80,14 +80,20 @@ export async function run(): Promise<void> {
     // truncation below leaves room for it instead of relying on api.ts's blunter fallback truncation.
     const TAG_OVERHEAD = `\n${COMMENT_TAG_PATTERN}`.length;
 
+    function shortSha(sha: string): string {
+        return sha.slice(0, 7);
+    }
+
     function diffHeaderBlock(diff: { owner: string; repo: string; beforeRev: string; rev: string }): string {
         return [
             `### [${diff.owner}/${diff.repo}](https://github.com/${diff.owner}/${diff.repo})`,
             "",
-            "<details><summary>Changelog</summary>",
-            "",
-            `[\`${diff.beforeRev}\` -> \`${diff.rev}\`](https://github.com/${diff.owner}/${diff.repo}/compare/${diff.beforeRev}..${diff.rev})`,
+            `[\`${shortSha(diff.beforeRev)}\` -> \`${shortSha(diff.rev)}\`](https://github.com/${diff.owner}/${diff.repo}/compare/${diff.beforeRev}..${diff.rev})`,
         ].join("\n");
+    }
+
+    function changelogAccordionOpenBlock(): string {
+        return ["", "<details><summary>Changelog</summary>", ""].join("\n");
     }
 
     function noCommonAncestorBlock(): string {
@@ -117,8 +123,8 @@ export async function run(): Promise<void> {
 
     function buildOmittedNote(owner: string, repo: string, beforeRev: string, rev: string, count: number): string {
         return (
-            "\n\n> [!NOTE]\n" +
-            `> ${count} more commit(s) were not shown (comment size limit). ` +
+            "\n\n> " +
+            `${count} more commit(s) were not shown (comment size limit). ` +
             `[View full comparison](https://github.com/${owner}/${repo}/compare/${beforeRev}..${rev})\n`
         );
     }
@@ -232,6 +238,7 @@ export async function run(): Promise<void> {
             reserved += `## ${lockfile}`.length + 1;
         }
         reserved += diffHeaderBlock(diff).length + 1;
+        reserved += changelogAccordionOpenBlock().length + 1;
         reserved += closingBlock().length + 1;
 
         if (relevant.length === 0 && irrelevant.length === 0) {
@@ -268,11 +275,18 @@ export async function run(): Promise<void> {
         result.push(diffHeaderBlock(diff));
 
         if (relevant.length === 0 && irrelevant.length === 0) {
+            result.push(changelogAccordionOpenBlock());
             result.push(closingBlock());
             result.push(noCommonAncestorBlock());
             await saveCacheForRepo(diff.owner, diff.repo);
             continue;
         }
+
+        if (relevant.length === 0) {
+            result.push(allIrrelevantNoteBlock());
+        }
+
+        result.push(changelogAccordionOpenBlock());
 
         let omittedRelevant = 0;
         if (relevant.length > 0) {
@@ -294,8 +308,7 @@ export async function run(): Promise<void> {
         }
 
         // The irrelevant accordion (and its own omitted-commits note, placed right
-        // after its closing tag) nests inside the outer accordion, same as the outer
-        // accordion's own note nests outside of it below.
+        // after its closing tag) nests inside the outer accordion.
         if (irrelevant.length > 0) {
             result.push(irrelevantAccordionOpenBlock(irrelevant.length));
 
@@ -325,9 +338,7 @@ export async function run(): Promise<void> {
 
         await saveCacheForRepo(diff.owner, diff.repo);
 
-        if (relevant.length === 0) {
-            result.push(allIrrelevantNoteBlock());
-        } else if (omittedRelevant > 0) {
+        if (omittedRelevant > 0) {
             result.push(buildOmittedNote(diff.owner, diff.repo, diff.beforeRev, diff.rev, omittedRelevant));
         }
     }


### PR DESCRIPTION
## Summary
- Move the "identical build output" note above the `Changelog` accordion, directly under the input name, instead of trailing after the accordion closes
- Move the commit range link (`before -> after`) outside the `Changelog` accordion, under the input name, and switch it to short commit hashes instead of full 40-character SHAs
- Fix the omitted-commits note ("N more commit(s) were not shown") which rendered as literal `[!NOTE]` text because the admonition syntax doesn't render properly nested inside a `<details>` block — now uses a plain `>` blockquote

## Test plan
- [x] `bun test` — all existing tests pass
- [x] `bun run typecheck`
- [x] `prettier --check src/main.ts`
- [x] `bun run build` to regenerate `dist/index.mjs`

---
_Generated by [Claude Code](https://claude.ai/code/session_01XQaDuTHwZu5vcufyksYJZU)_