### PR TITLE
Fix build-filter bisect endpoint and paginate past the compare API's 250-commit cap

### DIFF
--- a/dist/index.mjs
+++ b/dist/index.mjs
@@ -66541,9 +66541,11 @@ async function compareCommits(owner, repo, base, head) {
   const cacheKey = `${owner}/${repo}@${base}...${head}`;
   const cached = compareCommitsCache.get(cacheKey);
   if (cached !== undefined) {
+    info(`compareCommits: ${cacheKey} — cache hit, ${cached.length} commit(s)`);
     return cached;
   }
   const client = getGithubClient();
+  info(`compareCommits: ${cacheKey} — comparing`);
   try {
     const { data: compareData } = await client.rest.repos.compareCommitsWithBasehead({
       owner,
@@ -66552,9 +66554,11 @@ async function compareCommits(owner, repo, base, head) {
     });
     let rawCommits = compareData.commits;
     const totalCommits = compareData.total_commits ?? rawCommits.length;
+    info(`compareCommits: ${cacheKey} — compare API returned ${rawCommits.length} of ${totalCommits} commit(s)`);
     if (totalCommits > rawCommits.length) {
       warning(`${owner}/${repo}@${base}...${head}: compare API returned ${rawCommits.length} of ${totalCommits} ` + "commits; fetching the remainder via the commits API.");
       rawCommits = await listCommitsBetween(client, owner, repo, base, head, totalCommits);
+      info(`compareCommits: ${cacheKey} — recovered ${rawCommits.length} commit(s) via pagination fallback`);
     }
     const result = rawCommits.map((commit) => ({
       sha: commit.sha,
@@ -66709,6 +66713,13 @@ import * as fs8 from "fs";
 import { spawnSync } from "node:child_process";
 import * as os8 from "os";
 import * as path12 from "path";
+var LOG_FINGERPRINT_MAX_LENGTH = 200;
+function truncateForLog(value, maxLength = LOG_FINGERPRINT_MAX_LENGTH) {
+  if (value.length <= maxLength) {
+    return value;
+  }
+  return `${value.slice(0, maxLength)}... (${value.length} chars total)`;
+}
 function spawnCmd(cmd, opts) {
   const result = spawnSync(cmd[0], cmd.slice(1), {
     ...opts?.cwd !== undefined ? { cwd: opts.cwd } : {},
@@ -66744,10 +66755,12 @@ function filterCommitsByBuildRelevance(commits, diff, buildCommand) {
   if (!isGitAvailable()) {
     throw new Error("git not found in PATH — cannot run build-filter");
   }
+  info(`build-filter: ${diff.owner}/${diff.repo} — evaluating ${commits.length} commit(s) between ` + `${diff.beforeRev} and ${diff.rev}`);
   const tmpDir = fs8.mkdtempSync(path12.join(os8.tmpdir(), "cflc-"));
   try {
     const repoPath = path12.join(tmpDir, "repo");
     const repoUrl = `https://github.com/${diff.owner}/${diff.repo}`;
+    info(`build-filter: cloning ${repoUrl}`);
     const cloneResult = spawnCmd(["git", "clone", "--filter=blob:none", "--no-checkout", repoUrl, repoPath]);
     if (cloneResult.exitCode !== 0) {
       throw new Error(`Failed to clone ${repoUrl}: ${cloneResult.stderr}`);
@@ -66756,6 +66769,7 @@ function filterCommitsByBuildRelevance(commits, diff, buildCommand) {
     const allShas = lastCommitSha === diff.rev ? [diff.beforeRev, ...commits.map((c) => c.sha)] : [diff.beforeRev, ...commits.map((c) => c.sha), diff.rev];
     const cmdParts = ["sh", "-c", buildCommand];
     const buildFn = (sha) => {
+      info(`build-filter: building ${sha}`);
       const checkoutResult = spawnCmd(["git", "checkout", sha], { cwd: repoPath });
       if (checkoutResult.exitCode !== 0) {
         throw new Error(`git checkout ${sha} failed: ${checkoutResult.stderr}`);
@@ -66772,23 +66786,33 @@ function filterCommitsByBuildRelevance(commits, diff, buildCommand) {
       if (result.exitCode !== 0) {
         throw new Error(`Build command failed at ${sha}: ${result.stderr}`);
       }
-      return result.stdout.trim();
+      const fingerprint = result.stdout.trim();
+      info(`build-filter: ${sha} fingerprint: ${truncateForLog(fingerprint)}`);
+      return fingerprint;
     };
     const outFirst = buildFn(allShas[0]);
     const outLast = buildFn(allShas[allShas.length - 1]);
     const outputs = new Map;
     outputs.set(0, outFirst);
     outputs.set(allShas.length - 1, outLast);
+    if (outFirst === outLast) {
+      info(`build-filter: ${diff.owner}/${diff.repo} — endpoints produced identical fingerprints`);
+    } else {
+      info(`build-filter: ${diff.owner}/${diff.repo} — endpoints differ, bisecting to find boundaries`);
+    }
     bisect(0, allShas.length - 1, outFirst, outLast, allShas, outputs, buildFn);
     const relevant = [];
     const irrelevant = [];
     for (let i = 0;i < commits.length; i++) {
-      if (outputs.get(i + 1) !== outputs.get(i)) {
+      const isRelevant = outputs.get(i + 1) !== outputs.get(i);
+      info(`build-filter: ${commits[i].sha} classified as ${isRelevant ? "relevant" : "irrelevant"}`);
+      if (isRelevant) {
         relevant.push(commits[i]);
       } else {
         irrelevant.push(commits[i]);
       }
     }
+    info(`build-filter: ${diff.owner}/${diff.repo} — ${relevant.length} relevant, ${irrelevant.length} ` + `irrelevant commit(s) out of ${commits.length}`);
     return { relevant, irrelevant };
   } finally {
     fs8.rmSync(tmpDir, { recursive: true, force: true });

--- a/dist/index.mjs
+++ b/dist/index.mjs
@@ -66431,10 +66431,10 @@ var GetFileContentAtCommit_default = `query GetFileContentAtCommit($owner: Strin
 `;
 
 // src/queries/GetPullRequestChangedFiles.graphql
-var GetPullRequestChangedFiles_default = `query GetPullRequestChangedFiles($owner: String!, $repo: String!, $prNumber: Int!) {
+var GetPullRequestChangedFiles_default = `query GetPullRequestChangedFiles($owner: String!, $repo: String!, $prNumber: Int!, $after: String) {
     repository(owner: $owner, name: $repo) {
         pullRequest(number: $prNumber) {
-            files(first: 100) {
+            files(first: 100, after: $after) {
                 totalCount
                 pageInfo {
                     endCursor
@@ -66468,15 +66468,27 @@ function getGithubClient() {
 async function getPullRequestChangedFiles(prNumber) {
   const client = getGithubClient();
   const { repo } = context4;
-  const result = await client.graphql(GetPullRequestChangedFiles_default, {
-    ...repo,
-    prNumber
-  });
-  const data = result.repository.pullRequest.files;
-  if (data.totalCount > data.nodes.length) {
+  const paths = [];
+  let after = null;
+  let totalCount = 0;
+  for (;; ) {
+    const result = await client.graphql(GetPullRequestChangedFiles_default, {
+      ...repo,
+      prNumber,
+      after
+    });
+    const data = result.repository.pullRequest.files;
+    totalCount = data.totalCount;
+    paths.push(...data.nodes.map((node) => node.path));
+    if (!data.pageInfo.hasNextPage) {
+      break;
+    }
+    after = data.pageInfo.endCursor;
+  }
+  if (totalCount > paths.length) {
     warning("Not all files were loaded due to a large PR diff, some files may be missing from the changelog.");
   }
-  return data.nodes.map((node) => node.path);
+  return paths;
 }
 async function getPullRequestRefs(prNumber) {
   const client = getGithubClient();
@@ -66502,6 +66514,29 @@ async function getFileContentAtCommit(commit, filePath) {
 }
 var compareCommitsCache = new Map;
 var prForCommitCache = new Map;
+async function listCommitsBetween(client, owner, repo, base, head, totalCommits) {
+  const collected = [];
+  const hardLimit = totalCommits * 4 + 1000;
+  for await (const { data: page } of client.paginate.iterator(client.rest.repos.listCommits, {
+    owner,
+    repo,
+    sha: head,
+    per_page: 100
+  })) {
+    for (const commit of page) {
+      if (commit.sha === base) {
+        return collected.reverse();
+      }
+      collected.push(commit);
+      if (collected.length >= hardLimit) {
+        warning(`${owner}/${repo}@${base}...${head}: gave up walking commit history after ${collected.length} ` + `commits without finding ${base}; changelog may be incomplete.`);
+        return collected.reverse();
+      }
+    }
+  }
+  warning(`${owner}/${repo}@${base}...${head}: reached the end of ${head}'s history without finding ${base}; ` + "changelog may be incomplete.");
+  return collected.reverse();
+}
 async function compareCommits(owner, repo, base, head) {
   const cacheKey = `${owner}/${repo}@${base}...${head}`;
   const cached = compareCommitsCache.get(cacheKey);
@@ -66515,7 +66550,13 @@ async function compareCommits(owner, repo, base, head) {
       repo,
       basehead: `${base}...${head}`
     });
-    const result = compareData.commits.map((commit) => ({
+    let rawCommits = compareData.commits;
+    const totalCommits = compareData.total_commits ?? rawCommits.length;
+    if (totalCommits > rawCommits.length) {
+      warning(`${owner}/${repo}@${base}...${head}: compare API returned ${rawCommits.length} of ${totalCommits} ` + "commits; fetching the remainder via the commits API.");
+      rawCommits = await listCommitsBetween(client, owner, repo, base, head, totalCommits);
+    }
+    const result = rawCommits.map((commit) => ({
       sha: commit.sha,
       message: commit.commit.message.split(`
 `)[0],
@@ -66711,7 +66752,8 @@ function filterCommitsByBuildRelevance(commits, diff, buildCommand) {
     if (cloneResult.exitCode !== 0) {
       throw new Error(`Failed to clone ${repoUrl}: ${cloneResult.stderr}`);
     }
-    const allShas = [diff.beforeRev, ...commits.map((c) => c.sha)];
+    const lastCommitSha = commits.length > 0 ? commits[commits.length - 1].sha : diff.beforeRev;
+    const allShas = lastCommitSha === diff.rev ? [diff.beforeRev, ...commits.map((c) => c.sha)] : [diff.beforeRev, ...commits.map((c) => c.sha), diff.rev];
     const cmdParts = ["sh", "-c", buildCommand];
     const buildFn = (sha) => {
       const checkoutResult = spawnCmd(["git", "checkout", sha], { cwd: repoPath });

--- a/src/api.test.ts
+++ b/src/api.test.ts
@@ -29,6 +29,10 @@ let existingCommentsList: Array<{ id: number; body: string }>;
 let compareCommitsMock: Mock<any>;
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 let listPRsMock: Mock<any>;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let listCommitsMock: Mock<any>;
+// Pages the fake `client.paginate.iterator` yields when walking listCommits(sha: head).
+let listCommitsPages: Array<Array<{ sha: string; commit: { message: string }; html_url: string }>>;
 
 beforeEach(async () => {
     const testToken = `test_token_${Math.random()}`;
@@ -36,6 +40,8 @@ beforeEach(async () => {
     createCommentMock = mock(async (_params: unknown) => {});
     updateCommentMock = mock(async (_params: unknown) => {});
     existingCommentsList = [];
+    listCommitsPages = [];
+    listCommitsMock = mock(async () => ({ data: [] }));
 
     const mockOctokit = {
         graphql: mock(async (query: string, variables: Record<string, unknown>) => {
@@ -114,18 +120,70 @@ beforeEach(async () => {
                             },
                         } satisfies GetPullRequestChangedFilesResponse;
                     }
+                    if (
+                        variables["owner"] === "test_owner" &&
+                        variables["repo"] === "test_repo" &&
+                        variables["prNumber"] === 20
+                    ) {
+                        // Simulates a PR with more than one page of changed files: page 1 has
+                        // no `after` cursor and reports hasNextPage; page 2 is fetched with
+                        // the cursor from page 1 and is the last page.
+                        if (variables["after"] == null) {
+                            return {
+                                repository: {
+                                    pullRequest: {
+                                        files: {
+                                            totalCount: 3,
+                                            pageInfo: {
+                                                endCursor: "page1-end",
+                                                hasNextPage: true,
+                                            },
+                                            nodes: [{ path: "a.txt" }, { path: "b.txt" }],
+                                        },
+                                    },
+                                },
+                            } satisfies GetPullRequestChangedFilesResponse;
+                        }
+                        if (variables["after"] === "page1-end") {
+                            return {
+                                repository: {
+                                    pullRequest: {
+                                        files: {
+                                            totalCount: 3,
+                                            pageInfo: {
+                                                endCursor: "page2-end",
+                                                hasNextPage: false,
+                                            },
+                                            nodes: [{ path: "c.txt" }],
+                                        },
+                                    },
+                                },
+                            } satisfies GetPullRequestChangedFilesResponse;
+                        }
+                        throw new Error("Invalid arguments");
+                    }
                     throw new Error("Invalid arguments");
                 default:
                     throw new Error("Invalid query");
             }
         }),
         paginate: {
-            // Yields existingCommentsList, which each test may populate before calling upsertComment.
-            iterator: mock((_fn: unknown, _params: unknown) =>
-                (async function* () {
+            // Routes to whichever fake page set the test populated, based on which rest
+            // method was passed in: existingCommentsList for issues.listComments (used by
+            // upsertComment), listCommitsPages for repos.listCommits (used by compareCommits'
+            // truncated-range fallback).
+            iterator: mock((fn: unknown, _params: unknown) => {
+                if (fn === listCommitsMock) {
+                    return (async function* () {
+                        for (const page of listCommitsPages) {
+                            yield { data: page };
+                        }
+                    })();
+                }
+                return (async function* () {
                     yield { data: existingCommentsList };
-                })(),
-            ),
+                })();
+            }),
         },
         rest: {
             issues: {
@@ -170,9 +228,31 @@ beforeEach(async () => {
                         if (owner === "test_owner" && repo === "test_repo" && basehead === "no_base...no_head") {
                             throw new Error("No common ancestor");
                         }
+                        if (owner === "test_owner" && repo === "test_repo" && basehead === "base000...head999") {
+                            // Simulates GitHub's compare API commit cap: total_commits reports
+                            // the true range size, but the commits array itself is truncated.
+                            return {
+                                data: {
+                                    total_commits: 5,
+                                    commits: [
+                                        {
+                                            sha: "e1",
+                                            commit: { message: "commit e1" },
+                                            html_url: "https://github.com/test_owner/test_repo/commit/e1",
+                                        },
+                                        {
+                                            sha: "e2",
+                                            commit: { message: "commit e2" },
+                                            html_url: "https://github.com/test_owner/test_repo/commit/e2",
+                                        },
+                                    ],
+                                },
+                            };
+                        }
                         throw new Error("Invalid arguments");
                     },
                 )),
+                listCommits: listCommitsMock,
                 listPullRequestsAssociatedWithCommit: (listPRsMock = mock(
                     async ({ owner, repo, commit_sha }: { owner: string; repo: string; commit_sha: string }) => {
                         if (owner === "test_owner" && repo === "test_repo" && commit_sha === "aaa111") {
@@ -234,6 +314,14 @@ describe("getPullRequestChangedFiles", () => {
             "Not all files were loaded due to a large PR diff, some files may be missing from the changelog.",
         );
         expect(files).toEqual(["text.txt", "text2.txt"]);
+    });
+
+    test("walks every page of a multi-page file list instead of stopping at the first", async () => {
+        // Regression test for the changed-files list only ever reading GraphQL's first
+        // page (100 files) despite pageInfo.hasNextPage being available to paginate on.
+        const files = await getPullRequestChangedFiles(20);
+        expect(files).toEqual(["a.txt", "b.txt", "c.txt"]);
+        expect(logMock).not.toHaveBeenCalled();
     });
 });
 
@@ -359,6 +447,54 @@ describe("compareCommits", () => {
         const commits = await compareCommits("test_owner", "test_repo", "no_base", "no_head");
         expect(commits).toEqual([]);
         expect(logMock).toHaveBeenCalled();
+    });
+
+    test("falls back to paginated listCommits when the compare API truncates the range", async () => {
+        // total_commits (5) exceeds the compare API's truncated commits array (2), so the
+        // full range should be recovered by walking listCommits(sha: head) back to base.
+        // Regression test for
+        // https://github.com/mdarocha/comment-flake-lock-changelog/issues/316
+        listCommitsPages = [
+            [
+                {
+                    sha: "e5",
+                    commit: { message: "commit e5" },
+                    html_url: "https://github.com/test_owner/test_repo/commit/e5",
+                },
+                {
+                    sha: "e4",
+                    commit: { message: "commit e4" },
+                    html_url: "https://github.com/test_owner/test_repo/commit/e4",
+                },
+                {
+                    sha: "e3",
+                    commit: { message: "commit e3" },
+                    html_url: "https://github.com/test_owner/test_repo/commit/e3",
+                },
+            ],
+            [
+                {
+                    sha: "e2",
+                    commit: { message: "commit e2" },
+                    html_url: "https://github.com/test_owner/test_repo/commit/e2",
+                },
+                {
+                    sha: "e1",
+                    commit: { message: "commit e1" },
+                    html_url: "https://github.com/test_owner/test_repo/commit/e1",
+                },
+                {
+                    sha: "base000",
+                    commit: { message: "base commit" },
+                    html_url: "https://github.com/test_owner/test_repo/commit/base000",
+                },
+            ],
+        ];
+
+        const commits = await compareCommits("test_owner", "test_repo", "base000", "head999");
+
+        expect(commits.map((c) => c.sha)).toEqual(["e1", "e2", "e3", "e4", "e5"]);
+        expect(logMock).toHaveBeenCalledWith(expect.stringContaining("compare API returned 2 of 5 commits"));
     });
 });
 

--- a/src/api.ts
+++ b/src/api.ts
@@ -151,10 +151,13 @@ export async function compareCommits(
     const cacheKey = `${owner}/${repo}@${base}...${head}`;
     const cached = compareCommitsCache.get(cacheKey);
     if (cached !== undefined) {
+        core.info(`compareCommits: ${cacheKey} — cache hit, ${cached.length} commit(s)`);
         return cached;
     }
 
     const client = getGithubClient();
+
+    core.info(`compareCommits: ${cacheKey} — comparing`);
 
     try {
         const { data: compareData } = await client.rest.repos.compareCommitsWithBasehead({
@@ -165,12 +168,16 @@ export async function compareCommits(
 
         let rawCommits: RawCommit[] = compareData.commits;
         const totalCommits = compareData.total_commits ?? rawCommits.length;
+        core.info(
+            `compareCommits: ${cacheKey} — compare API returned ${rawCommits.length} of ${totalCommits} commit(s)`,
+        );
         if (totalCommits > rawCommits.length) {
             core.warning(
                 `${owner}/${repo}@${base}...${head}: compare API returned ${rawCommits.length} of ${totalCommits} ` +
                     "commits; fetching the remainder via the commits API.",
             );
             rawCommits = await listCommitsBetween(client, owner, repo, base, head, totalCommits);
+            core.info(`compareCommits: ${cacheKey} — recovered ${rawCommits.length} commit(s) via pagination fallback`);
         }
 
         const result = rawCommits.map((commit) => ({

--- a/src/api.ts
+++ b/src/api.ts
@@ -21,17 +21,37 @@ export async function getPullRequestChangedFiles(prNumber: number): Promise<stri
     const client = getGithubClient();
     const { repo } = github.context;
 
-    const result = await client.graphql<GetPullRequestChangedFilesResponse>(GetPullRequestChangedFilesQuery, {
-        ...repo,
-        prNumber,
-    });
+    const paths: string[] = [];
+    let after: string | null = null;
+    let totalCount = 0;
 
-    const data = result.repository.pullRequest.files;
-    if (data.totalCount > data.nodes.length) {
+    // The PR's file list is paginated by GitHub's GraphQL API (100 per page); walk every
+    // page via pageInfo.hasNextPage/endCursor instead of only ever reading the first one.
+    for (;;) {
+        const result: GetPullRequestChangedFilesResponse = await client.graphql<GetPullRequestChangedFilesResponse>(
+            GetPullRequestChangedFilesQuery,
+            {
+                ...repo,
+                prNumber,
+                after,
+            },
+        );
+
+        const data = result.repository.pullRequest.files;
+        totalCount = data.totalCount;
+        paths.push(...data.nodes.map((node) => node.path));
+
+        if (!data.pageInfo.hasNextPage) {
+            break;
+        }
+        after = data.pageInfo.endCursor;
+    }
+
+    if (totalCount > paths.length) {
         core.warning("Not all files were loaded due to a large PR diff, some files may be missing from the changelog.");
     }
 
-    return data.nodes.map((node) => node.path);
+    return paths;
 }
 
 export async function getPullRequestRefs(prNumber: number): Promise<{ base: string; head: string }> {
@@ -71,6 +91,57 @@ export function clearCaches(): void {
     prForCommitCache.clear();
 }
 
+type RawCommit = { sha: string; commit: { message: string }; html_url: string };
+
+/**
+ * GitHub's compare API caps the `commits` array at 250 entries regardless of the
+ * range's real size (`total_commits` reports the true count but the array itself
+ * isn't paginated further). When that cap is hit, walk `head`'s history via the
+ * (properly paginated) commits API instead, collecting everything down to `base`,
+ * so ranges beyond the cap aren't silently dropped from the changelog or the
+ * build-filter bisect.
+ */
+async function listCommitsBetween(
+    client: ReturnType<typeof getGithubClient>,
+    owner: string,
+    repo: string,
+    base: string,
+    head: string,
+    totalCommits: number,
+): Promise<RawCommit[]> {
+    const collected: RawCommit[] = [];
+    // Safety margin in case history doesn't converge on `base` within a sane number
+    // of commits (e.g. unexpected force-push); avoids paginating indefinitely.
+    const hardLimit = totalCommits * 4 + 1000;
+
+    for await (const { data: page } of client.paginate.iterator(client.rest.repos.listCommits, {
+        owner,
+        repo,
+        sha: head,
+        per_page: 100,
+    })) {
+        for (const commit of page as RawCommit[]) {
+            if (commit.sha === base) {
+                return collected.reverse();
+            }
+            collected.push(commit);
+            if (collected.length >= hardLimit) {
+                core.warning(
+                    `${owner}/${repo}@${base}...${head}: gave up walking commit history after ${collected.length} ` +
+                        `commits without finding ${base}; changelog may be incomplete.`,
+                );
+                return collected.reverse();
+            }
+        }
+    }
+
+    core.warning(
+        `${owner}/${repo}@${base}...${head}: reached the end of ${head}'s history without finding ${base}; ` +
+            "changelog may be incomplete.",
+    );
+    return collected.reverse();
+}
+
 export async function compareCommits(
     owner: string,
     repo: string,
@@ -92,7 +163,17 @@ export async function compareCommits(
             basehead: `${base}...${head}`,
         });
 
-        const result = compareData.commits.map((commit) => ({
+        let rawCommits: RawCommit[] = compareData.commits;
+        const totalCommits = compareData.total_commits ?? rawCommits.length;
+        if (totalCommits > rawCommits.length) {
+            core.warning(
+                `${owner}/${repo}@${base}...${head}: compare API returned ${rawCommits.length} of ${totalCommits} ` +
+                    "commits; fetching the remainder via the commits API.",
+            );
+            rawCommits = await listCommitsBetween(client, owner, repo, base, head, totalCommits);
+        }
+
+        const result = rawCommits.map((commit) => ({
             sha: commit.sha,
             message: commit.commit.message.split("\n")[0],
             url: commit.html_url,

--- a/src/build-filter.test.ts
+++ b/src/build-filter.test.ts
@@ -109,4 +109,52 @@ describe("filterCommitsByBuildRelevance", () => {
         expect(relevant.map((c) => c.sha)).toEqual(["c1"]);
         expect(irrelevant.map((c) => c.sha)).toEqual(["c2"]);
     });
+
+    test("bisects against diff.rev, not the last entry of a truncated commits array", async () => {
+        const { filterCommitsByBuildRelevance } = await import("~/buildFilter");
+
+        // Simulates compareCommits' 250-commit API cap: the `commits` array passed in
+        // stops at "c2", but the real range extends to diff.rev ("head"), where a
+        // relevant change actually lives beyond what's visible in `commits`. Regression
+        // test for https://github.com/mdarocha/comment-flake-lock-changelog/issues/316.
+        //
+        // Attributing the change to a specific commit is only possible once the caller
+        // (compareCommits) also paginates past the cap — covered separately in
+        // api.test.ts — but even without that, the bisect's upper endpoint must reflect
+        // the real head so the range is never wrongly reported as fully identical.
+        outputsBySha = { before: "out-a", c1: "out-a", c2: "out-a", head: "out-b" };
+
+        const { relevant } = filterCommitsByBuildRelevance(
+            [
+                { sha: "c1", message: "commit 1", url: "https://example.com/c1" },
+                { sha: "c2", message: "commit 2", url: "https://example.com/c2" },
+            ],
+            { owner: "NixOS", repo: "nixpkgs", beforeRev: "before", rev: "head", name: "nixpkgs" },
+            'echo "$CFLC_INPUT_REV"',
+        );
+
+        // Before the fix, the bisect never built "head" at all — its endpoint was
+        // commits[commits.length - 1].sha ("c2"), whose output matches "before", so the
+        // range would be silently misreported as unaffected. Even though this particular
+        // list is too incomplete for any single commit to take the blame, the endpoint
+        // itself must be checked against the true head rather than the truncated list.
+        expect(relevant).toEqual([]);
+        const buildShas = spawnCalls.filter((c) => c.cmd === "sh").map((c) => c.env?.["CFLC_INPUT_REV"]);
+        expect(buildShas).toContain("head");
+    });
+
+    test("does not build an extra redundant commit when the last visible commit is already diff.rev", async () => {
+        const { filterCommitsByBuildRelevance } = await import("~/buildFilter");
+
+        outputsBySha = { before: "out-a", c1: "out-b" };
+
+        filterCommitsByBuildRelevance(
+            [{ sha: "c1", message: "commit 1", url: "https://example.com/c1" }],
+            { owner: "acme", repo: "flake-utils", beforeRev: "before", rev: "c1", name: "flake-utils" },
+            'echo "$CFLC_INPUT_REV"',
+        );
+
+        const buildShas = spawnCalls.filter((c) => c.cmd === "sh").map((c) => c.env?.["CFLC_INPUT_REV"]);
+        expect(buildShas).toEqual(["before", "c1"]);
+    });
 });

--- a/src/buildFilter.ts
+++ b/src/buildFilter.ts
@@ -99,8 +99,16 @@ export function filterCommitsByBuildRelevance(
             throw new Error(`Failed to clone ${repoUrl}: ${cloneResult.stderr}`);
         }
 
-        // allShas[0] = beforeRev, allShas[1..N] = commits[0..N-1].sha
-        const allShas = [diff.beforeRev, ...commits.map((c) => c.sha)];
+        // allShas[0] = beforeRev, allShas[1..N] = commits[0..N-1].sha. The final element
+        // is always diff.rev (the actual head of the range) rather than commits[N-1].sha:
+        // compareCommits' underlying API caps how many commits it returns per call, so if
+        // that cap is ever hit the last entry in `commits` would not be the true head and
+        // the bisect's upper endpoint would silently land short of the real range.
+        const lastCommitSha = commits.length > 0 ? commits[commits.length - 1].sha : diff.beforeRev;
+        const allShas =
+            lastCommitSha === diff.rev
+                ? [diff.beforeRev, ...commits.map((c) => c.sha)]
+                : [diff.beforeRev, ...commits.map((c) => c.sha), diff.rev];
 
         const cmdParts = ["sh", "-c", buildCommand];
 

--- a/src/buildFilter.ts
+++ b/src/buildFilter.ts
@@ -1,7 +1,17 @@
+import * as core from "@actions/core";
 import * as fs from "fs";
 import { spawnSync } from "node:child_process";
 import * as os from "os";
 import * as path from "path";
+
+const LOG_FINGERPRINT_MAX_LENGTH = 200;
+
+function truncateForLog(value: string, maxLength = LOG_FINGERPRINT_MAX_LENGTH): string {
+    if (value.length <= maxLength) {
+        return value;
+    }
+    return `${value.slice(0, maxLength)}... (${value.length} chars total)`;
+}
 
 type Commit = { sha: string; message: string; url: string };
 
@@ -88,11 +98,17 @@ export function filterCommitsByBuildRelevance(
         throw new Error("git not found in PATH \u2014 cannot run build-filter");
     }
 
+    core.info(
+        `build-filter: ${diff.owner}/${diff.repo} \u2014 evaluating ${commits.length} commit(s) between ` +
+            `${diff.beforeRev} and ${diff.rev}`,
+    );
+
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "cflc-"));
     try {
         const repoPath = path.join(tmpDir, "repo");
         const repoUrl = `https://github.com/${diff.owner}/${diff.repo}`;
 
+        core.info(`build-filter: cloning ${repoUrl}`);
         // Blobless clone: fetch tree metadata only; blobs are fetched on demand during checkout.
         const cloneResult = spawnCmd(["git", "clone", "--filter=blob:none", "--no-checkout", repoUrl, repoPath]);
         if (cloneResult.exitCode !== 0) {
@@ -113,6 +129,7 @@ export function filterCommitsByBuildRelevance(
         const cmdParts = ["sh", "-c", buildCommand];
 
         const buildFn = (sha: string): string => {
+            core.info(`build-filter: building ${sha}`);
             const checkoutResult = spawnCmd(["git", "checkout", sha], { cwd: repoPath });
             if (checkoutResult.exitCode !== 0) {
                 throw new Error(`git checkout ${sha} failed: ${checkoutResult.stderr}`);
@@ -129,7 +146,9 @@ export function filterCommitsByBuildRelevance(
             if (result.exitCode !== 0) {
                 throw new Error(`Build command failed at ${sha}: ${result.stderr}`);
             }
-            return result.stdout.trim();
+            const fingerprint = result.stdout.trim();
+            core.info(`build-filter: ${sha} fingerprint: ${truncateForLog(fingerprint)}`);
+            return fingerprint;
         };
 
         // Build at endpoints
@@ -140,6 +159,12 @@ export function filterCommitsByBuildRelevance(
         outputs.set(0, outFirst);
         outputs.set(allShas.length - 1, outLast);
 
+        if (outFirst === outLast) {
+            core.info(`build-filter: ${diff.owner}/${diff.repo} — endpoints produced identical fingerprints`);
+        } else {
+            core.info(`build-filter: ${diff.owner}/${diff.repo} — endpoints differ, bisecting to find boundaries`);
+        }
+
         // Bisect to find all change boundaries
         bisect(0, allShas.length - 1, outFirst, outLast, allShas, outputs, buildFn);
 
@@ -148,12 +173,19 @@ export function filterCommitsByBuildRelevance(
         const irrelevant: Commit[] = [];
 
         for (let i = 0; i < commits.length; i++) {
-            if (outputs.get(i + 1) !== outputs.get(i)) {
+            const isRelevant = outputs.get(i + 1) !== outputs.get(i);
+            core.info(`build-filter: ${commits[i].sha} classified as ${isRelevant ? "relevant" : "irrelevant"}`);
+            if (isRelevant) {
                 relevant.push(commits[i]);
             } else {
                 irrelevant.push(commits[i]);
             }
         }
+
+        core.info(
+            `build-filter: ${diff.owner}/${diff.repo} — ${relevant.length} relevant, ${irrelevant.length} ` +
+                `irrelevant commit(s) out of ${commits.length}`,
+        );
 
         return { relevant, irrelevant };
     } finally {

--- a/src/queries/GetPullRequestChangedFiles.graphql
+++ b/src/queries/GetPullRequestChangedFiles.graphql
@@ -1,7 +1,7 @@
-query GetPullRequestChangedFiles($owner: String!, $repo: String!, $prNumber: Int!) {
+query GetPullRequestChangedFiles($owner: String!, $repo: String!, $prNumber: Int!, $after: String) {
     repository(owner: $owner, name: $repo) {
         pullRequest(number: $prNumber) {
-            files(first: 100) {
+            files(first: 100, after: $after) {
                 totalCount
                 pageInfo {
                     endCursor


### PR DESCRIPTION
## Summary

Fixes #316.

- **`build-filter` bisect fix**: `filterCommitsByBuildRelevance` now always bisects against `diff.rev` (the true head of the range) instead of `commits[commits.length - 1].sha`. Previously, if `commits` was ever truncated or otherwise short of the real range, the bisect's upper endpoint would silently be wrong.
- **`compareCommits` pagination**: GitHub's compare API caps its `commits` array at 250 entries regardless of the range's real size (`total_commits` reports the true count, but the array itself isn't paginated further). `compareCommits` now detects when `total_commits` exceeds what was returned and falls back to walking `client.rest.repos.listCommits` (which does paginate properly) from `head` back down to `base`, recovering the full range instead of silently dropping commits beyond the cap.
- **`getPullRequestChangedFiles` pagination** (found while auditing for other missing pagination per the issue's ask): this only ever read the first GraphQL page of a PR's changed files (100 files) and just logged a warning if `totalCount` exceeded what was fetched, even though `pageInfo.hasNextPage`/`endCursor` were already being requested and unused. It now walks every page.

## Test plan

- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] `bun test` (added regression tests for the bisect endpoint fix, the `compareCommits` pagination fallback, and the `getPullRequestChangedFiles` multi-page walk)
- [x] `bun run build` (regenerated `dist/index.mjs`)


---
_Generated by [Claude Code](https://claude.ai/code/session_019CU7mpywzEt9Nyg4BkbLrB)_