### PR TITLE
Fix the GitHub API result cache so it actually persists across runs

### DIFF
--- a/dist/index.mjs
+++ b/dist/index.mjs
@@ -66662,15 +66662,17 @@ async function getPullRequestDetails(prNumber) {
     body: data.body ?? ""
   };
 }
-function getCacheKeyAndPath(owner, repo) {
-  const key = `comment-flake-lock-changelog-v1-${owner}-${repo}`;
-  const filePath = path11.join(os7.tmpdir(), `${key}.json`);
-  return { key, filePath };
+function getCachePrefix(owner, repo) {
+  return `comment-flake-lock-changelog-v1-${owner}-${repo}`;
+}
+function getCacheFilePath(owner, repo) {
+  return path11.join(os7.tmpdir(), `${getCachePrefix(owner, repo)}.json`);
 }
 async function restoreCacheForRepo(owner, repo) {
-  const { key, filePath } = getCacheKeyAndPath(owner, repo);
+  const prefix2 = getCachePrefix(owner, repo);
+  const filePath = getCacheFilePath(owner, repo);
   try {
-    const hit = await restoreCache([filePath], key);
+    const hit = await restoreCache([filePath], prefix2, [prefix2]);
     if (!hit) {
       return;
     }
@@ -66687,7 +66689,8 @@ async function restoreCacheForRepo(owner, repo) {
   }
 }
 async function saveCacheForRepo(owner, repo) {
-  const { key, filePath } = getCacheKeyAndPath(owner, repo);
+  const prefix2 = getCachePrefix(owner, repo);
+  const filePath = getCacheFilePath(owner, repo);
   try {
     const compareCommitsEntries = {};
     for (const [k, commits] of compareCommitsCache.entries()) {
@@ -66702,7 +66705,9 @@ async function saveCacheForRepo(owner, repo) {
       prForCommit: prForCommitEntries
     };
     fs7.writeFileSync(filePath, JSON.stringify(cacheFile), "utf8");
-    await saveCache2([filePath], key);
+    const runId = process.env["GITHUB_RUN_ID"] ?? Date.now().toString();
+    const runAttempt = process.env["GITHUB_RUN_ATTEMPT"] ?? "1";
+    await saveCache2([filePath], `${prefix2}-${runId}-${runAttempt}`);
   } catch (err) {
     debug(`Cache save unavailable or failed: ${String(err)}`);
   }

--- a/src/api.test.ts
+++ b/src/api.test.ts
@@ -1,5 +1,8 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import type { Mock } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
 import {
     clearCaches,
     compareCommits,
@@ -8,6 +11,8 @@ import {
     getPullRequestDetails,
     getPullRequestForCommit,
     getPullRequestRefs,
+    restoreCacheForRepo,
+    saveCacheForRepo,
     upsertComment,
 } from "~/api";
 import GetFileContentAtCommitQuery from "~/queries/GetFileContentAtCommit.graphql" with { type: "text" };
@@ -519,5 +524,92 @@ describe("getPullRequestForCommit", () => {
         await getPullRequestForCommit("test_owner", "test_repo", "no_pr_commit");
         await getPullRequestForCommit("test_owner", "test_repo", "no_pr_commit");
         expect(listPRsMock).toHaveBeenCalledTimes(1);
+    });
+});
+
+describe("restoreCacheForRepo / saveCacheForRepo", () => {
+    let restoreCacheMock: Mock<
+        (paths: string[], primaryKey: string, restoreKeys?: string[]) => Promise<string | undefined>
+    >;
+    let saveCacheMock: Mock<(paths: string[], key: string) => Promise<number>>;
+    let cacheModuleMock: Awaited<ReturnType<typeof mockModule>>;
+    const filePath = path.join(os.tmpdir(), "comment-flake-lock-changelog-v1-test_owner-test_repo.json");
+    const originalRunId = process.env["GITHUB_RUN_ID"];
+    const originalRunAttempt = process.env["GITHUB_RUN_ATTEMPT"];
+
+    beforeEach(async () => {
+        restoreCacheMock = mock(async () => undefined);
+        saveCacheMock = mock(async () => 0);
+        cacheModuleMock = await mockModule("@actions/cache", () => ({
+            restoreCache: restoreCacheMock,
+            saveCache: saveCacheMock,
+        }));
+        fs.rmSync(filePath, { force: true });
+    });
+
+    afterEach(() => {
+        cacheModuleMock.dispose();
+        fs.rmSync(filePath, { force: true });
+        if (originalRunId === undefined) {
+            delete process.env["GITHUB_RUN_ID"];
+        } else {
+            process.env["GITHUB_RUN_ID"] = originalRunId;
+        }
+        if (originalRunAttempt === undefined) {
+            delete process.env["GITHUB_RUN_ATTEMPT"];
+        } else {
+            process.env["GITHUB_RUN_ATTEMPT"] = originalRunAttempt;
+        }
+    });
+
+    test("restoreCacheForRepo restores via a prefix fallback, not just an exact key", async () => {
+        await restoreCacheForRepo("test_owner", "test_repo");
+
+        expect(restoreCacheMock).toHaveBeenCalledTimes(1);
+        const [, primaryKey, restoreKeys] = restoreCacheMock.mock.calls[0] as [string[], string, string[]];
+        // Real saves are always suffixed (see below), so an exact match on the bare
+        // prefix should never hit - restoreKeys is what actually finds a prior save.
+        expect(restoreKeys).toEqual([primaryKey]);
+    });
+
+    test("saveCacheForRepo never reuses the same key across two runs, so neither save collides with the other", async () => {
+        process.env["GITHUB_RUN_ID"] = "111";
+        process.env["GITHUB_RUN_ATTEMPT"] = "1";
+        await saveCacheForRepo("test_owner", "test_repo");
+        const [, firstKey] = saveCacheMock.mock.calls[0] as [string[], string];
+
+        process.env["GITHUB_RUN_ID"] = "222";
+        process.env["GITHUB_RUN_ATTEMPT"] = "1";
+        await saveCacheForRepo("test_owner", "test_repo");
+        const [, secondKey] = saveCacheMock.mock.calls[1] as [string[], string];
+
+        expect(saveCacheMock).toHaveBeenCalledTimes(2);
+        expect(firstKey).not.toBe(secondKey);
+        // Neither save key is the bare prefix either - that's the literal key the old,
+        // broken implementation used, and it's exactly what made every save after the
+        // first one on a branch fail silently (GitHub Actions caches are immutable per
+        // exact key).
+        expect(firstKey).not.toBe("comment-flake-lock-changelog-v1-test_owner-test_repo");
+        expect(secondKey).not.toBe("comment-flake-lock-changelog-v1-test_owner-test_repo");
+    });
+
+    test("a cache hit on restore populates compareCommits' cache, so a matching call skips the API", async () => {
+        fs.writeFileSync(
+            filePath,
+            JSON.stringify({
+                compareCommits: {
+                    "test_owner/test_repo@abc123...def456": [{ sha: "cached-sha", message: "cached", url: "u" }],
+                },
+                prForCommit: {},
+            }),
+            "utf8",
+        );
+        restoreCacheMock.mockImplementation(async () => "some-previous-run-key");
+
+        await restoreCacheForRepo("test_owner", "test_repo");
+        const commits = await compareCommits("test_owner", "test_repo", "abc123", "def456");
+
+        expect(commits).toEqual([{ sha: "cached-sha", message: "cached", url: "u" }]);
+        expect(compareCommitsMock).not.toHaveBeenCalled();
     });
 });

--- a/src/api.ts
+++ b/src/api.ts
@@ -321,16 +321,35 @@ interface CacheFile {
     prForCommit: Record<string, { id: number; url: string } | null>;
 }
 
-function getCacheKeyAndPath(owner: string, repo: string): { key: string; filePath: string } {
-    const key = `comment-flake-lock-changelog-v1-${owner}-${repo}`;
-    const filePath = path.join(os.tmpdir(), `${key}.json`);
-    return { key, filePath };
+// GitHub Actions caches are immutable per exact key within a scope (branch):
+// once a key exists, every later attempt to save to that same key fails. A bare,
+// unversioned prefix as the literal key (the previous approach here) meant the
+// very first successful save on a branch permanently "froze" the cache — every
+// later run on that branch restored that same first snapshot but silently failed
+// to persist anything newer (the failure only ever surfaced via a hidden
+// core.debug call), and every *different* branch (the common case: a fresh
+// per-bump PR from update-flake-lock, this action's own documented example) never
+// matched the exact key at all, so it never benefited from caching in the first
+// place. Save under a key suffixed with the run/attempt (always unique, so the
+// save always succeeds) and restore via a prefix match on the stable prefix (so a
+// later run still finds the most recent save regardless of its exact suffix) —
+// the same primary-key + restore-prefix split cache-nix-action itself uses.
+function getCachePrefix(owner: string, repo: string): string {
+    return `comment-flake-lock-changelog-v1-${owner}-${repo}`;
+}
+
+function getCacheFilePath(owner: string, repo: string): string {
+    return path.join(os.tmpdir(), `${getCachePrefix(owner, repo)}.json`);
 }
 
 export async function restoreCacheForRepo(owner: string, repo: string): Promise<void> {
-    const { key, filePath } = getCacheKeyAndPath(owner, repo);
+    const prefix = getCachePrefix(owner, repo);
+    const filePath = getCacheFilePath(owner, repo);
     try {
-        const hit = await cache.restoreCache([filePath], key);
+        // primaryKey never exact-matches (actual saves are always suffixed), so this
+        // always falls through to the restoreKeys prefix match against the most
+        // recent save.
+        const hit = await cache.restoreCache([filePath], prefix, [prefix]);
         if (!hit) {
             return;
         }
@@ -348,7 +367,8 @@ export async function restoreCacheForRepo(owner: string, repo: string): Promise<
 }
 
 export async function saveCacheForRepo(owner: string, repo: string): Promise<void> {
-    const { key, filePath } = getCacheKeyAndPath(owner, repo);
+    const prefix = getCachePrefix(owner, repo);
+    const filePath = getCacheFilePath(owner, repo);
     try {
         const compareCommitsEntries: CacheFile["compareCommits"] = {};
         for (const [k, commits] of compareCommitsCache.entries()) {
@@ -363,7 +383,9 @@ export async function saveCacheForRepo(owner: string, repo: string): Promise<voi
             prForCommit: prForCommitEntries,
         };
         fs.writeFileSync(filePath, JSON.stringify(cacheFile), "utf8");
-        await cache.saveCache([filePath], key);
+        const runId = process.env["GITHUB_RUN_ID"] ?? Date.now().toString();
+        const runAttempt = process.env["GITHUB_RUN_ATTEMPT"] ?? "1";
+        await cache.saveCache([filePath], `${prefix}-${runId}-${runAttempt}`);
     } catch (err) {
         core.debug(`Cache save unavailable or failed: ${String(err)}`);
     }


### PR DESCRIPTION
## The bug

`restoreCacheForRepo`/`saveCacheForRepo` (which cache `compareCommits` and `getPullRequestForCommit` results, keyed by the upstream input's owner/repo, to avoid redundant GitHub API calls) used a completely static cache key: `comment-flake-lock-changelog-v1-<owner>-<repo>`. `restoreCache` was called with no `restoreKeys` fallback (an exact-match-only lookup), and `saveCache` was called with that same literal key every time.

GitHub Actions caches are **immutable per exact key within a scope** (a scope being roughly "this branch, falling back to the base branch"). That combination means:

- The very first successful save on a given branch creates the cache under that exact key.
- Every *later* run on that **same branch** restores that same frozen first snapshot, but its own `saveCache` call always fails — the key already exists — silently, since the failure is only ever routed through `core.debug` (invisible in a normal log; you'd need step debugging enabled to ever see it). The cache is effectively frozen after its first successful write.
- Every run on a **different branch** — which is this action's own documented use case, a fresh branch per `flake.lock` bump PR from `update-flake-lock` — gets a cache scope that's never had anything saved in it before, so it's a guaranteed miss, every time. In the common case, this cache provided no benefit at all.

Not a correctness bug (the cached `compareCommits` entries are keyed by an exact, immutable commit range, so a stale hit is still a *correct* hit for that range) — but the entire point of the cache was defeated for most real usage.

## The fix

Split save and restore the same way `cache-nix-action` (already used elsewhere in this ecosystem, e.g. in [nix-magic-setup](https://github.com/mdarocha/nix-magic-setup)) does:

- `saveCacheForRepo` suffixes the key with `$GITHUB_RUN_ID-$GITHUB_RUN_ATTEMPT`, so every save gets a key that's guaranteed unique and never collides with a prior save.
- `restoreCacheForRepo` passes the bare, stable prefix as a `restoreKeys` fallback (the `primaryKey` itself is passed too, but never exact-matches anymore, since real saves are always suffixed) — GitHub's cache restore treats `restoreKeys` entries as prefixes and returns the most recently created match, so this still finds whatever was last saved regardless of its exact suffix.

## Test plan
- [x] `bun test` — 46 pass (3 new: restore passes a `restoreKeys` prefix fallback rather than only an exact key, two saves in different runs get different keys and neither is the bare prefix, and a cache hit on restore actually populates `compareCommits`' in-memory cache so a matching call skips the API)
- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] `bun run format:check`
- [x] `bun run build` (dist/index.mjs rebuilt and committed)


---
_Generated by [Claude Code](https://claude.ai/code/session_016MYz49D9GAahQN6haYW3Nb)_