### PR TITLE
fix(api): treat compare-commits 404 as a warning, not a fatal error

### DIFF
--- a/dist/index.mjs
+++ b/dist/index.mjs
@@ -66587,6 +66587,12 @@ async function compareCommits(owner, repo, base, head) {
       compareCommitsCache.set(cacheKey, empty);
       return empty;
     }
+    if (typeof error2 === "object" && error2 !== null && "status" in error2 && error2.status === 404) {
+      warning(`compareCommits: ${owner}/${repo}@${base}...${head} — GitHub returned 404 comparing these ` + "commits (one of them is likely unreachable upstream, e.g. garbage-collected or rewritten). " + "Skipping commit changelog for this input.");
+      const empty = [];
+      compareCommitsCache.set(cacheKey, empty);
+      return empty;
+    }
     throw error2;
   }
 }

--- a/src/api.test.ts
+++ b/src/api.test.ts
@@ -237,6 +237,11 @@ beforeEach(async () => {
                         if (owner === "test_owner" && repo === "test_repo" && basehead === "no_base...no_head") {
                             throw new Error("No common ancestor");
                         }
+                        if (owner === "test_owner" && repo === "test_repo" && basehead === "gone_base...gone_head") {
+                            const notFound = new Error("Not Found") as Error & { status: number };
+                            notFound.status = 404;
+                            throw notFound;
+                        }
                         if (owner === "test_owner" && repo === "test_repo" && basehead === "base000...head999") {
                             // Simulates GitHub's compare API commit cap: total_commits reports
                             // the true range size, but the commits array itself is truncated.
@@ -457,6 +462,12 @@ describe("compareCommits", () => {
         const commits = await compareCommits("test_owner", "test_repo", "no_base", "no_head");
         expect(commits).toEqual([]);
         expect(logMock).toHaveBeenCalled();
+    });
+
+    test("returns empty array on 404 (unreachable commit upstream)", async () => {
+        const commits = await compareCommits("test_owner", "test_repo", "gone_base", "gone_head");
+        expect(commits).toEqual([]);
+        expect(logMock).toHaveBeenCalledWith(expect.stringContaining("GitHub returned 404 comparing these commits"));
     });
 
     test("falls back to paginated listCommits when the compare API truncates the range", async () => {

--- a/src/api.ts
+++ b/src/api.ts
@@ -235,6 +235,22 @@ export async function compareCommits(
             compareCommitsCache.set(cacheKey, empty);
             return empty;
         }
+        // GitHub 404s a commit comparison when either endpoint is unreachable from
+        // the API's perspective — most commonly an upstream flake input revision
+        // that was garbage-collected or rewritten away after the lockfile pinned
+        // it. That's routine for fast-moving inputs (nixpkgs-unstable, etc.), not
+        // an error in this action or the PR under test, so degrade to a warning
+        // and an empty changelog for this input rather than failing the whole run.
+        if (typeof error === "object" && error !== null && "status" in error && error.status === 404) {
+            core.warning(
+                `compareCommits: ${owner}/${repo}@${base}...${head} — GitHub returned 404 comparing these ` +
+                    "commits (one of them is likely unreachable upstream, e.g. garbage-collected or rewritten). " +
+                    "Skipping commit changelog for this input.",
+            );
+            const empty: Array<{ sha: string; message: string; url: string }> = [];
+            compareCommitsCache.set(cacheKey, empty);
+            return empty;
+        }
         throw error;
     }
 }


### PR DESCRIPTION
## Problem
`compareCommits()` in `src/api.ts` calls `client.rest.repos.compareCommitsWithBasehead()` for every changed flake input. When one endpoint of the range (usually the *before* revision of a fast-moving input like `nixpkgs-unstable`) has since been garbage-collected or rewritten away upstream, GitHub returns 404 and the error was rethrown uncaught — failing the whole action run, and with it every consuming repo's required `Check`/CI status on any PR that touches `flake.lock` (seen across `robo-intern`, `robo-intern-v2`, `mdarocha.pl`, `pondinfra`, and this repo's own PRs, e.g. #335).

## Fix
Handle a 404 the same way the existing `No common ancestor` case is already handled: log `core.warning(...)` and return an empty commit list for that one input, instead of throwing. The changelog comment simply omits that input's commit list; every other input is unaffected.

## Testing
- Added `returns empty array on 404 (unreachable commit upstream)` to `src/api.test.ts`, mocking an `Error` with `status: 404` the way Octokit's `RequestError` shapes it.
- `bun test` — 71 pass, 0 fail.
- `bunx eslint .` — clean.
- `bunx prettier --check` — clean.
- Rebuilt `dist/index.mjs` via `bun run build` (bundle must stay in sync per the `build` pre-commit hook).

Once merged, repos pinning this action (directly, or via `mdarocha/nix-magic-setup`) should bump their pin to pick this up.