### PR TITLE
chore: bump nix-magic-setup to v1.4.0

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -17,6 +17,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v4
-      - uses: mdarocha/nix-magic-setup@fbeadb287d13c1f3a3c2ccd9b7fb0f6201300997 # v1.3.0
+      - uses: mdarocha/nix-magic-setup@e36d43dfbb22e406645941eb20ab8b8e276f0ebc # v1.4.0
 
       - run: devenv test


### PR DESCRIPTION
Bumps the `mdarocha/nix-magic-setup` action pin from `v1.3.0` to `v1.4.0` in `.github/workflows/check.yml`.

v1.4.0 picks up the `compare-commits` 404 fix this repo just shipped in #336 (self-referential: this repo's own `check.yml` workflow uses `nix-magic-setup`, which nests `comment-flake-lock-changelog@v1.0.3`, so our own CI was failing on `nix-dependencies` dependabot PRs like #335 for the same reason before that fix landed).

No other files reference the pin.