### PR TITLE
chore: bump nix-magic-setup pin (pending #336 fix)

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -17,6 +17,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v4
-      - uses: mdarocha/nix-magic-setup@fbeadb287d13c1f3a3c2ccd9b7fb0f6201300997 # v1.3.0
+      - uses: mdarocha/nix-magic-setup@1921e811898d32305cfbf959a6b9d6adf520df41 # unreleased: nix-magic-setup#25
 
       - run: devenv test


### PR DESCRIPTION
Bumps the pinned `mdarocha/nix-magic-setup` action SHA in `.github/workflows/check.yml` to the HEAD of `bump/comment-flake-lock-changelog-unreleased-fix` (mdarocha/nix-magic-setup#25), which itself points at the `main` commit from #336 that fixes the `compareCommits()` 404 handling.

**Depends on:** mdarocha/nix-magic-setup#25 being merged and (ideally) tagged as a release before this is merged, since the pin currently references an unreleased branch commit (annotated `# unreleased: nix-magic-setup#25`).

**Why this is needed:** this repo's own CI (`check.yml`) dogfoods `nix-magic-setup`, which recursively invokes `comment-flake-lock-changelog` on PRs. Dependabot PR #335 (nix-dependencies bump) is currently failing CI on the exact same `compareCommitsWithBasehead` 404 bug that was just fixed on `main` via #336 — but that fix hasn't shipped in a `nix-magic-setup` release yet, so CI still runs the old broken code path through the pinned action SHA. Bumping the pin here unblocks #335 and any other PR whose CI run depends on nix-magic-setup's dogfooded self-check.

Not merging this myself — please review and merge once mdarocha/nix-magic-setup#25 lands.