### PR TITLE
docs: tighten comments and README prose

### DIFF
--- a/dist/index.mjs
+++ b/dist/index.mjs
@@ -67129,10 +67129,15 @@ ${COMMENT_TAG_PATTERN}`.length;
     }
   }
   const gathered = [];
+  const restoredRepos = new Set;
   for (const { lockfile, diffs } of allDiffsByLockfile) {
     for (const diff of diffs) {
       info(`Checking ${diff.owner}/${diff.repo} ${diff.beforeRev} -> ${diff.rev}`);
-      await restoreCacheForRepo(diff.owner, diff.repo);
+      const repoKey = `${diff.owner}/${diff.repo}`;
+      if (!restoredRepos.has(repoKey)) {
+        restoredRepos.add(repoKey);
+        await restoreCacheForRepo(diff.owner, diff.repo);
+      }
       const commits = await compareCommits(diff.owner, diff.repo, diff.beforeRev, diff.rev);
       let relevant = commits;
       let irrelevant = [];

--- a/src/api.ts
+++ b/src/api.ts
@@ -376,19 +376,12 @@ interface CacheFile {
     buildFilterResults: Record<string, BuildFilterResult>;
 }
 
-// GitHub Actions caches are immutable per exact key within a scope (branch):
-// once a key exists, every later attempt to save to that same key fails. A bare,
-// unversioned prefix as the literal key (the previous approach here) meant the
-// very first successful save on a branch permanently "froze" the cache — every
-// later run on that branch restored that same first snapshot but silently failed
-// to persist anything newer (the failure only ever surfaced via a hidden
-// core.debug call), and every *different* branch (the common case: a fresh
-// per-bump PR from update-flake-lock, this action's own documented example) never
-// matched the exact key at all, so it never benefited from caching in the first
-// place. Save under a key suffixed with the run/attempt (always unique, so the
-// save always succeeds) and restore via a prefix match on the stable prefix (so a
-// later run still finds the most recent save regardless of its exact suffix) —
-// the same primary-key + restore-prefix split cache-nix-action itself uses.
+// GitHub Actions cache keys are immutable per exact match within a branch scope: once a
+// key exists, every later save to it silently fails. Save under a key suffixed with the
+// run and attempt number (always unique, so the save always succeeds) and restore via a
+// prefix match against the stable prefix (so a later run still finds the most recent save
+// regardless of its exact suffix) — the same primary-key + restore-prefix split
+// cache-nix-action itself uses.
 function getCachePrefix(owner: string, repo: string): string {
     return `comment-flake-lock-changelog-v1-${owner}-${repo}`;
 }

--- a/src/buildFilter.ts
+++ b/src/buildFilter.ts
@@ -204,12 +204,10 @@ export function filterCommitsByBuildRelevance(
                 : [diff.beforeRev, ...commits.map((c) => c.sha), diff.rev];
 
         // Blobless clone: fetch tree metadata only; blobs are fetched on demand during
-        // checkout. Deliberately a full clone, not a partial/shallow fetch of just the
-        // commits in this range: a git-init-plus-per-commit-fetch repo (no branches, no
-        // full ref graph) has twice now made Nix's git+file fetcher fail against it in
-        // real testing, so this sticks with the one approach that's actually held up —
-        // same lesson as build-filter-skip-checkout, reverted for a related reason (see
-        // the README's 'Disk space' section).
+        // checkout. Deliberately a full clone, not a partial fetch of just the commits in
+        // this range — a git-init-plus-per-commit-fetch repo (no branches, no full ref
+        // graph) makes Nix's git+file fetcher fail against it. See the README's 'Disk
+        // space' section for the disk-usage tradeoffs this implies.
         core.info(`build-filter: cloning ${repoUrl}`);
         const cloneResult = spawnCmd(["git", "clone", "--filter=blob:none", "--no-checkout", repoUrl, repoPath]);
         if (cloneResult.exitCode !== 0) {

--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -36,6 +36,7 @@ let filterCommitsByBuildRelevanceMock: Mock<any>;
 let getCachedBuildFilterResultMock: Mock<any>;
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 let setCachedBuildFilterResultMock: Mock<any>;
+let restoreCacheForRepoMock: Mock<(owner: string, repo: string) => Promise<void>>;
 
 beforeEach(async () => {
     upsertCommentMock = mock(async () => {});
@@ -57,6 +58,7 @@ beforeEach(async () => {
     filterCommitsByBuildRelevanceMock = mock((commits: any[]) => ({ relevant: commits, irrelevant: [] }));
     getCachedBuildFilterResultMock = mock(() => undefined);
     setCachedBuildFilterResultMock = mock(() => {});
+    restoreCacheForRepoMock = mock(async () => {});
 
     moduleMocks = [
         await mockModule("@actions/core", () => ({
@@ -79,7 +81,7 @@ beforeEach(async () => {
             compareCommits: compareCommitsMock,
             getPullRequestForCommit: mock(async () => null),
             upsertComment: upsertCommentMock,
-            restoreCacheForRepo: mock(async () => {}),
+            restoreCacheForRepo: restoreCacheForRepoMock,
             saveCacheForRepo: mock(async () => {}),
             buildFilterCacheKey: mock(
                 (nixStateHash: string, buildCommand: string, diff: { beforeRev: string; rev: string; name: string }) =>
@@ -223,6 +225,38 @@ describe("run", () => {
         expect(body).toContain("commit 0 in flake-utils");
         expect((body.match(/more commit\(s\) were not shown/g) ?? []).length).toBeGreaterThanOrEqual(1);
         expect(body.length).toBeLessThan(65536);
+    });
+
+    test("restores a repo's cache only once even when two inputs point at the same repo", async () => {
+        getPullRequestDetailsMock.mockImplementation(async () => ({
+            authorLogin: "someone",
+            body: "",
+        }));
+
+        const BEFORE_SAME_REPO = JSON.stringify({
+            nodes: {
+                root: { inputs: { nixpkgs: "nixpkgs", "nixpkgs-unstable": "nixpkgs-unstable" } },
+                nixpkgs: { locked: { owner: "NixOS", repo: "nixpkgs", rev: "aaaa1111", type: "github" } },
+                "nixpkgs-unstable": { locked: { owner: "NixOS", repo: "nixpkgs", rev: "cccc3333", type: "github" } },
+            },
+        });
+        const AFTER_SAME_REPO = JSON.stringify({
+            nodes: {
+                root: { inputs: { nixpkgs: "nixpkgs", "nixpkgs-unstable": "nixpkgs-unstable" } },
+                nixpkgs: { locked: { owner: "NixOS", repo: "nixpkgs", rev: "bbbb2222", type: "github" } },
+                "nixpkgs-unstable": { locked: { owner: "NixOS", repo: "nixpkgs", rev: "dddd4444", type: "github" } },
+            },
+        });
+        getFileContentAtCommitMock.mockImplementation(async (commit: string, _path: string) =>
+            commit === "basesha" ? BEFORE_SAME_REPO : AFTER_SAME_REPO,
+        );
+
+        // dynamic import required: same reason as above.
+        const { run } = await import("~/main");
+        await run();
+
+        expect(restoreCacheForRepoMock).toHaveBeenCalledTimes(1);
+        expect(restoreCacheForRepoMock).toHaveBeenCalledWith("NixOS", "nixpkgs");
     });
 
     test("never logs a per-commit PR-lookup line via core.info, even over a large irrelevant list", async () => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -283,10 +283,21 @@ export async function run(): Promise<void> {
     }
     const gathered: GatheredDiff[] = [];
 
+    // Multiple inputs (or multiple lockfiles) can point at the same upstream repo in
+    // one PR — e.g. both a "nixpkgs" and "nixpkgs-unstable" input, or the same input
+    // bumped in two flake.lock files. Restoring the same repo's cache twice in one run
+    // wastes a network round trip and risks the second restore clobbering entries this
+    // run already computed with a stale snapshot from before this run started.
+    const restoredRepos = new Set<string>();
+
     for (const { lockfile, diffs } of allDiffsByLockfile) {
         for (const diff of diffs) {
             core.info(`Checking ${diff.owner}/${diff.repo} ${diff.beforeRev} -> ${diff.rev}`);
-            await restoreCacheForRepo(diff.owner, diff.repo);
+            const repoKey = `${diff.owner}/${diff.repo}`;
+            if (!restoredRepos.has(repoKey)) {
+                restoredRepos.add(repoKey);
+                await restoreCacheForRepo(diff.owner, diff.repo);
+            }
             const commits = await compareCommits(diff.owner, diff.repo, diff.beforeRev, diff.rev);
 
             let relevant = commits;


### PR DESCRIPTION
## Summary

**Part 1 — runtime/disk-usage investigation** (build-filter bisection, commit-range fetching, nix invocation count, git fetch/checkout scope): reviewed `src/buildFilter.ts`, `src/main.ts`, and `src/api.ts`'s `compareCommits`/cache helpers in full. All four areas called out (bisection-loop growth, full-range materialization, redundant `nix` calls, fetch/checkout narrowness) are already handled correctly by prior work (#322, #323, #324, #336) — no changes needed there, see PR description below for the detailed per-file findings.

While reading `main.ts`'s per-diff loop, found one real (if minor) inefficiency outside the four listed areas: `restoreCacheForRepo(owner, repo)` was called once per lockfile *diff* rather than once per unique upstream *repo*, so a PR that bumps two inputs pointing at the same GitHub repo (e.g. `nixpkgs` + `nixpkgs-unstable`, or the same input bumped in two `flake.lock` files) would restore that repo's Actions cache twice — an extra network round trip, and a theoretical risk of a second restore clobbering cache entries this run already computed with a stale snapshot. Fixed by deduping restores with a `Set` of already-restored `owner/repo` keys, covered by a new test (`main.test.ts`: "restores a repo's cache only once even when two inputs point at the same repo").

**Part 2 — comment/README humanization**: read the full diff since `v1.0.2` for `README.md`, `action.yml`, and `src/**/*.ts`. The README and most in-code comments already read like a careful human design note (the repo's own `AGENTS.md` style) and were left untouched. Two comments crossed into changelog-narration territory and were tightened to state the current rationale without narrating the debugging history:

- `src/api.ts` (`getCachePrefix`): a 13-line comment explicitly describing "the previous approach here" and the exact failure mode it caused — trimmed to the rationale for the current key-suffix/restore-prefix split.
- `src/buildFilter.ts` (blobless clone): a comment narrating "has twice now made ... fail ... in real testing" and referencing an internal-only codename ("build-filter-skip-checkout, reverted for a related reason") — trimmed to the actual constraint (no full ref graph) with a pointer to the README's Disk space section.

## Verification

- `bun test` — 72 pass, 0 fail
- `bun run typecheck` — clean
- `bun run lint` — clean
- `bun run format:check` — clean
- `bun run build` — `dist/index.mjs` rebuilt and committed (src/ changed)
